### PR TITLE
UIMARCAUTH-20: Implement Results List Column Chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * [UIMARCAUTH-6](https://issues.folio.org/browse/UIMARCAUTH-6) Add View MARC authority record permission.
 * [UIMARCAUTH-5](https://issues.folio.org/browse/UIMARCAUTH-5) Add Edit MARC authority record permission.
 * [UIMARCAUTH-16](https://issues.folio.org/browse/UIMARCAUTH-16) Implement MARC Authorities Search Box.
+* [UIMARCAUTH-20](https://issues.folio.org/browse/UIMARCAUTH-20) Implement Results List Column Chooser.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "inflected": "^2.0.4",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
+    "lodash": "^4.17.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { MultiColumnList } from '@folio/stripes/components';
 
 import { AuthorityShape } from '../../constants/shapes';
+import { searchResultListColumns } from '../../constants';
 
 const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
@@ -11,15 +12,10 @@ const propTypes = {
   onNeedMoreData: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   totalResults: PropTypes.number,
+  visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 const authRef = 'Auth/Ref';
-
-const searchResultListColumns = {
-  AUTH_REF_TYPE: 'authRefType',
-  HEADING_REF: 'headingRef',
-  HEADING_TYPE: 'headingType',
-};
 
 const SearchResultsList = ({
   authorities,
@@ -27,6 +23,7 @@ const SearchResultsList = ({
   loading,
   pageSize,
   onNeedMoreData,
+  visibleColumns,
 }) => {
   const columnMapping = {
     [searchResultListColumns.AUTH_REF_TYPE]: <FormattedMessage id="ui-marc-authorities.search-results-list.authRefType" />,
@@ -45,11 +42,6 @@ const SearchResultsList = ({
         : authority.authRefType;
     },
   };
-  const visibleColumns = [
-    searchResultListColumns.AUTH_REF_TYPE,
-    searchResultListColumns.HEADING_REF,
-    searchResultListColumns.HEADING_TYPE,
-  ];
 
   return (
     <MultiColumnList

--- a/src/components/SearchResultsList/SearchResultsList.test.js
+++ b/src/components/SearchResultsList/SearchResultsList.test.js
@@ -6,11 +6,17 @@ import noop from 'lodash/noop';
 import Harness from '../../../test/jest/helpers/harness';
 import SearchResultsList from './SearchResultsList';
 import authorities from '../../../mocks/authorities.json';
+import { searchResultListColumns } from '../../constants';
 
 const renderSearchResultsList = (props = {}) => render(
   <Harness>
     <SearchResultsList
       authorities={authorities}
+      visibleColumns={[
+        searchResultListColumns.AUTH_REF_TYPE,
+        searchResultListColumns.HEADING_REF,
+        searchResultListColumns.HEADING_TYPE,
+      ]}
       totalResults={authorities.length}
       loading={false}
       pageSize={15}
@@ -25,5 +31,28 @@ describe('Given SearchResultsList', () => {
     const { getAllByText } = renderSearchResultsList();
 
     expect(getAllByText('Twain, Mark')).toHaveLength(15);
+  });
+
+  it('should display 3 columns', () => {
+    const { getByText } = renderSearchResultsList();
+
+    expect(getByText('ui-marc-authorities.search-results-list.authRefType')).toBeDefined();
+    expect(getByText('ui-marc-authorities.search-results-list.headingRef')).toBeDefined();
+    expect(getByText('ui-marc-authorities.search-results-list.headingType')).toBeDefined();
+  });
+
+  describe('when show columns checkbox for "Type of Heading" is not checked', () => {
+    it('should display 2 columns', () => {
+      const { queryByText } = renderSearchResultsList({
+        visibleColumns: [
+          searchResultListColumns.AUTH_REF_TYPE,
+          searchResultListColumns.HEADING_REF,
+        ],
+      });
+
+      expect(queryByText('ui-marc-authorities.search-results-list.authRefType')).toBeDefined();
+      expect(queryByText('ui-marc-authorities.search-results-list.headingRef')).toBeDefined();
+      expect(queryByText('ui-marc-authorities.search-results-list.headingType')).toBeNull();
+    });
   });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 export * from './searchableIndexesValues';
 export * from './rawSearchableIndexes';
 export * from './searchableIndexesMap';
+export * from './searchResultsListColumns';

--- a/src/constants/searchResultsListColumns.js
+++ b/src/constants/searchResultsListColumns.js
@@ -1,0 +1,5 @@
+export const searchResultListColumns = {
+  AUTH_REF_TYPE: 'authRefType',
+  HEADING_REF: 'headingRef',
+  HEADING_TYPE: 'headingType',
+};

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -6,7 +6,10 @@ import {
   useHistory,
   useLocation,
 } from 'react-router-dom';
-import { useIntl } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import queryString from 'query-string';
 import {
   useLocalStorage,
@@ -24,6 +27,8 @@ import {
   CollapseFilterPaneButton,
   ExpandFilterPaneButton,
   PersistedPaneset,
+  useColumnManager,
+  ColumnManagerMenu,
 } from '@folio/stripes/smart-components';
 
 import {
@@ -36,9 +41,14 @@ import {
   SearchResultsList,
 } from '../../components';
 import { useAuthorities } from '../../hooks/useAuthorities';
-import { rawSearchableIndexes } from '../../constants';
+import {
+  rawSearchableIndexes,
+  searchResultListColumns,
+} from '../../constants';
 
 import css from './AuthoritiesSearch.css';
+
+const prefix = 'authorities';
 
 const AuthoritiesSearch = () => {
   const intl = useIntl();
@@ -54,6 +64,16 @@ const AuthoritiesSearch = () => {
 
   const [searchDropdownValue, setSearchDropdownValue] = useState('');
   const [searchIndex, setSearchIndex] = useState('');
+
+  const columnMapping = {
+    [searchResultListColumns.AUTH_REF_TYPE]: <FormattedMessage id="ui-marc-authorities.search-results-list.authRefType" />,
+    [searchResultListColumns.HEADING_REF]: <FormattedMessage id="ui-marc-authorities.search-results-list.headingRef" />,
+    [searchResultListColumns.HEADING_TYPE]: <FormattedMessage id="ui-marc-authorities.search-results-list.headingType" />,
+  };
+  const {
+    visibleColumns,
+    toggleColumn,
+  } = useColumnManager(prefix, columnMapping);
 
   useEffect(() => {
     const locationSearchParams = queryString.parse(location.search);
@@ -118,6 +138,18 @@ const AuthoritiesSearch = () => {
           onClick={toggleFilterPane}
         />
       </PaneMenu>
+    );
+  };
+
+  const renderActionMenu = () => {
+    return (
+      <ColumnManagerMenu
+        prefix={prefix}
+        visibleColumns={visibleColumns}
+        toggleColumn={toggleColumn}
+        columnMapping={columnMapping}
+        excludeColumns={[searchResultListColumns.HEADING_REF]}
+      />
     );
   };
 
@@ -189,12 +221,14 @@ const AuthoritiesSearch = () => {
         defaultWidth="fill"
         paneTitle={intl.formatMessage({ id: 'ui-marc-authorities.meta.title' })}
         firstMenu={renderResultsFirstMenu()}
+        actionMenu={renderActionMenu}
       >
         <SearchResultsList
           authorities={authorities}
           totalResults={totalRecords}
           pageSize={pageSize}
           onNeedMoreData={onFetchNextPage}
+          visibleColumns={visibleColumns}
         />
       </Pane>
     </PersistedPaneset>


### PR DESCRIPTION
# UIMARCAUTH-20 Authorities Search > Implement Results List Column Chooser

## Purpose
- Add Action button on results pane.
- Add checkboxes with visibility status of `SearchResultsList` columns
- Add tests
- add `lodash` package

Issue: [UIMARCAUTH-20](https://issues.folio.org/browse/UIMARCAUTH-20)

## Learning
We could test child component's props as html attributes, but for objects or arrays in props we should check them as strings.

```
jest.mock('../../components', () => ({
  ...jest.requireActual('../../components'),
  SearchResultsList: (props) => {
    const mapedProps = mockMapValues(props, (prop) => (typeof prop === 'object') ? JSON.stringify(prop) : prop);

    return <div data-testid='SearchResultsList' {...mapedProps} />;
  },
}));
...
describe('when click on "Type of Heading" checkbox', () => {
  it('should hide "Type of Heading" column', () => {
    const { getByTestId } = renderAuthoritiesSearch();

    fireEvent.click(getByTestId('checkbox-headingType'));

    expect(getByTestId('SearchResultsList')).toHaveAttribute("activeColumns", JSON.stringify({
      [searchResultListColumns.AUTH_REF_TYPE]: true,
      [searchResultListColumns.HEADING_TYPE]: false,
    }));
  });
});
```

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/145218436-bcf4f2a4-ccc5-47b5-8a7f-d531080bc4f4.png)
