### PR TITLE
Fix subPermissions for View and Edit permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "permissionName": "ui-marc-authorities.authority-record.view",
         "displayName": "View MARC authority record",
         "subPermissions": [
+          "module.marc-authorities.enabled",
           "records-editor.records.item.get",
           "search.authorities.collection.get"
         ],
@@ -104,6 +105,7 @@
         "permissionName": "ui-marc-authorities.authority-record.edit",
         "displayName": "Edit MARC authority record",
         "subPermissions": [
+          "ui-marc-authorities.authority-record.view",
           "records-editor.records.item.put"
         ],
         "visible": true


### PR DESCRIPTION
## Description
Fix two permissions:

- To `ui-marc-authorities.authority-record.view` add `module.marc-authorities.enabled`. This enabled the modules for users who can view MARC Authority records
- To `ui-marc-authorities.authority-record.edit` add `ui-marc-authorities.authority-record.view`. This enables users who can edit records to also search and view them
