### PR TITLE
UIMARCAUTH-34: Search Options dropdown: Remove Authority UUID search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 * [UIMARCAUTH-14](https://issues.folio.org/browse/UIMARCAUTH-14) Display a Date Created filter.
 * [UIMARCAUTH-31](https://issues.folio.org/browse/UIMARCAUTH-31) Fix formatting of search query string.
 * [UIMARCAUTH-19](https://issues.folio.org/browse/UIMARCAUTH-19) Implement Results List Sort options.
+* [UIMARCAUTH-34](https://issues.folio.org/browse/UIMARCAUTH-34) Remove Authority UUID search option.

--- a/src/constants/rawSearchableIndexes.js
+++ b/src/constants/rawSearchableIndexes.js
@@ -11,5 +11,4 @@ export const rawSearchableIndexes = [
   { label: 'ui-marc-authorities.subject', value: searchableIndexesValues.SUBJECT },
   { label: 'ui-marc-authorities.childrenSubjectHeading', value: searchableIndexesValues.CHILDREN_SUBJECT_HEADING },
   { label: 'ui-marc-authorities.genre', value: searchableIndexesValues.GENRE },
-  { label: 'ui-marc-authorities.authorityUUID', value: searchableIndexesValues.AUTHORITY_UUID },
 ];

--- a/src/constants/searchableIndexesMap.js
+++ b/src/constants/searchableIndexesMap.js
@@ -63,8 +63,4 @@ export const searchableIndexesMap = {
     sft: true,
     saft: true,
   }],
-  [searchableIndexesValues.AUTHORITY_UUID]: [{
-    name: 'id',
-    plain: true,
-  }],
 };

--- a/src/constants/searchableIndexesValues.js
+++ b/src/constants/searchableIndexesValues.js
@@ -9,5 +9,4 @@ export const searchableIndexesValues = {
   SUBJECT: 'subject',
   CHILDREN_SUBJECT_HEADING: 'childrenSubjectHeading',
   GENRE: 'genre',
-  AUTHORITY_UUID: 'authorityUUID',
 };

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -21,7 +21,6 @@
   "subject": "Subject",
   "childrenSubjectHeading": "Children's subject heading",
   "genre": "Genre",
-  "authorityUUID": "Authority UUID",
   "marcHeading": "MARC authority record",
   "authorityRecordSubtitle": "{heading} • Last updated: {lastUpdatedDate}",
   "createdDate": "Date created",


### PR DESCRIPTION
## Purpose
Remove Authority UUID search option from the Search Options dropdown.

Issue: [UIMARCAUTH-34](https://issues.folio.org/browse/UIMARCAUTH-34)