### PR TITLE
UIMARCAUTH-40: Fix Results List column headers are smushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 * [UIMARCAUTH-14](https://issues.folio.org/browse/UIMARCAUTH-14) Display a Date Created filter.
 * [UIMARCAUTH-31](https://issues.folio.org/browse/UIMARCAUTH-31) Fix formatting of search query string.
 * [UIMARCAUTH-19](https://issues.folio.org/browse/UIMARCAUTH-19) Implement Results List Sort options.
+* [UIMARCAUTH-40](https://issues.folio.org/browse/UIMARCAUTH-40) Fix Results List column headers are smushed.

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import {
   useLocation,
@@ -50,19 +50,20 @@ const SearchResultsList = ({
   toggleFilterPane,
   hasFilters,
 }) => {
+  const intl = useIntl();
   const location = useLocation();
   const match = useRouteMatch();
 
   const columnMapping = {
-    [searchResultListColumns.AUTH_REF_TYPE]: <FormattedMessage id="ui-marc-authorities.search-results-list.authRefType" />,
-    [searchResultListColumns.HEADING_REF]: <FormattedMessage id="ui-marc-authorities.search-results-list.headingRef" />,
-    [searchResultListColumns.HEADING_TYPE]: <FormattedMessage id="ui-marc-authorities.search-results-list.headingType" />,
+    [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'ui-marc-authorities.search-results-list.authRefType' }),
+    [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'ui-marc-authorities.search-results-list.headingRef' }),
+    [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'ui-marc-authorities.search-results-list.headingType' }),
   };
 
   const columnWidths = {
-    [searchResultListColumns.AUTH_REF_TYPE]: '25%',
-    [searchResultListColumns.HEADING_REF]: '40%',
-    [searchResultListColumns.HEADING_TYPE]: '35%',
+    [searchResultListColumns.AUTH_REF_TYPE]: { min: 200 },
+    [searchResultListColumns.HEADING_REF]: { min: 400 },
+    [searchResultListColumns.HEADING_TYPE]: { min: 200 },
   };
 
   const formatter = {
@@ -105,6 +106,7 @@ const SearchResultsList = ({
       pending: () => loading,
       failure: () => { },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [loading, hasFilters],
   );
 


### PR DESCRIPTION
## Purpose
Fix Results List column headers are smushed when third pane is opened.

## Approach
The approach was chosen based on the [readme.md](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/readme.md) for MultiColumnList where it is said:

> Prefer pixel `px` values to percent values. <...> percents `%` are less practical and often result columns being overly squeezed

## Screenshots
![3r0mluEZoo](https://user-images.githubusercontent.com/84023879/146571761-f21e0b8f-3f19-4e13-b59c-58f3ce6e8c07.gif)

## Issues
[UIMARCAUTH-40](https://issues.folio.org/browse/UIMARCAUTH-40)
