### PR TITLE
UIMARCAUTH-36: Update second line heading on QuickMarc view pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 * [UIMARCAUTH-17](https://issues.folio.org/browse/UIMARCAUTH-17) Display a Exclude see from limiter.
 * [UIMARCAUTH-40](https://issues.folio.org/browse/UIMARCAUTH-40) Fix Results List column headers are smushed.
 * [UIMARCAUTH-34](https://issues.folio.org/browse/UIMARCAUTH-34) Remove Authority UUID search option.
+* [UIMARCAUTH-36](https://issues.folio.org/browse/UIMARCAUTH-36) Update second line heading on QuickMarc view pane.

--- a/src/components/MultiSelectionFacet/MultiSelectionFacet.js
+++ b/src/components/MultiSelectionFacet/MultiSelectionFacet.js
@@ -74,7 +74,6 @@ const MultiSelectionFacet = ({
       id={id}
       open={open}
       onToggle={handleSectionToggle}
-      separator={false}
       header={FilterAccordionHeader}
       onClearFilter={() => onClearFilter(name)}
       displayClearButton={displayClearButton}

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -100,7 +100,7 @@ const SearchFilters = ({
 
       <AcqDateRangeFilter
         activeFilters={activeFilters?.createdDate || []}
-        labelId="ui-marc-authorities.createdDate"
+        labelId="ui-marc-authorities.search.createdDate"
         id="createdDate"
         name="createdDate"
         onChange={applyFilters}
@@ -111,7 +111,7 @@ const SearchFilters = ({
 
       <AcqDateRangeFilter
         activeFilters={activeFilters?.updatedDate || []}
-        labelId="ui-marc-authorities.updatedDate"
+        labelId="ui-marc-authorities.search.updatedDate"
         id="updatedDate"
         name="updatedDate"
         onChange={applyFilters}

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -41,7 +41,7 @@ const AuthorityView = ({
       paneSub={intl.formatMessage({
         id: 'ui-marc-authorities.authorityRecordSubtitle',
       }, {
-        heading: authority.data.headingRef,
+        heading: authority.data.headingType,
         lastUpdatedDate: intl.formatDate(marcSource.data.metadata.lastUpdatedDate),
       })}
       marcTitle={intl.formatMessage({ id: 'ui-marc-authorities.marcHeading' })}


### PR DESCRIPTION
# MARC Authorities App: View MARC authority record > Update second line heading requirement

## Purpose
-  Change `headingRef` to `headingType`
- update translations 
- add separator to type of heading accordion

Issue: [UIMARCAUTH-36](https://issues.folio.org/browse/UIMARCAUTH-36)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/147742563-b806ad72-fe20-4c42-82a7-f0c549b62558.png)

