### PR TITLE
UIMARCAUTH-46: Cannot get Authority record search - Identifiers search option to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 * [UIMARCAUTH-32](https://issues.folio.org/browse/UIMARCAUTH-32) Search box - Hit enter key must run search.
 * [UIMARCAUTH-36](https://issues.folio.org/browse/UIMARCAUTH-36) Update second line heading on QuickMarc view pane.
 * [UIMARCAUTH-45](https://issues.folio.org/browse/UIMARCAUTH-45) Add Edit button on MarcView Pane.
+* [UIMARCAUTH-46](https://issues.folio.org/browse/UIMARCAUTH-46) Fix Cannot get Authority record search - Identifiers search option to work

--- a/src/constants/searchableIndexesMap.js
+++ b/src/constants/searchableIndexesMap.js
@@ -6,7 +6,7 @@ export const searchableIndexesMap = {
     plain: true,
   }],
   [searchableIndexesValues.IDENTIFIER]: [{
-    name: 'identifier',
+    name: 'identifiers.value',
     plain: true,
   }],
   [searchableIndexesValues.PERSONAL_NAME]: [{

--- a/src/constants/searchableIndexesValues.js
+++ b/src/constants/searchableIndexesValues.js
@@ -1,6 +1,6 @@
 export const searchableIndexesValues = {
   KEYWORD: 'keyword',
-  IDENTIFIER: 'identifier',
+  IDENTIFIER: 'identifiers.value',
   PERSONAL_NAME: 'personalName',
   CORPORATE_CONFERENCE_NAME: 'corporateConferenceName',
   GEOGRAPHIC_NAME: 'geographicName',

--- a/src/queries/utils/buildQuery.js
+++ b/src/queries/utils/buildQuery.js
@@ -26,34 +26,36 @@ const buildQuery = ({
       queryParts.push(query);
     }
 
-    if (!isExcludedSeeFromLimiter) {
-      if ((data.sft || data.saft) && data.plain) {
-        const name = upperFirst(data.name);
+    if (isExcludedSeeFromLimiter) {
+      return queryParts;
+    }
 
-        if (data.sft) {
-          const query = queryTemplate(`sft${name}`);
+    if ((data.sft || data.saft) && data.plain) {
+      const name = upperFirst(data.name);
 
-          queryParts.push(query);
-        }
-
-        if (data.saft) {
-          const query = queryTemplate(`saft${name}`);
-
-          queryParts.push(query);
-        }
-      }
-
-      if (data.sft && !data.plain) {
-        const query = queryTemplate(data.name);
+      if (data.sft) {
+        const query = queryTemplate(`sft${name}`);
 
         queryParts.push(query);
       }
 
-      if (data.saft && !data.plain) {
-        const query = queryTemplate(data.name);
+      if (data.saft) {
+        const query = queryTemplate(`saft${name}`);
 
         queryParts.push(query);
       }
+    }
+
+    if (data.sft && !data.plain) {
+      const query = queryTemplate(data.name);
+
+      queryParts.push(query);
+    }
+
+    if (data.saft && !data.plain) {
+      const query = queryTemplate(data.name);
+
+      queryParts.push(query);
     }
 
     return queryParts;

--- a/src/queries/utils/buildQuery.js
+++ b/src/queries/utils/buildQuery.js
@@ -11,6 +11,10 @@ const buildQuery = ({
 }) => {
   const indexData = searchableIndexesMap[searchIndex || searchableIndexesValues.KEYWORD];
 
+  if (!indexData) {
+    return '';
+  }
+
   const queryStrings = indexData.map(data => {
     const queryParts = [];
 

--- a/src/queries/utils/buildQuery.test.js
+++ b/src/queries/utils/buildQuery.test.js
@@ -9,7 +9,7 @@ describe('Given buildQuery', () => {
         isExcludedSeeFromLimiter: true,
       });
 
-      expect(query).toBe('(identifier=="%{query}")');
+      expect(query).toBe('(identifiers.value=="%{query}")');
     });
   });
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -12,7 +12,7 @@ import AuthoritiesSearch from './AuthoritiesSearch';
 import '../../../test/jest/__mock__';
 import Harness from '../../../test/jest/helpers/harness';
 import {
-  searchableIndexesValues,
+  rawSearchableIndexes,
   searchResultListColumns,
   sortOrders,
 } from '../../constants';
@@ -81,8 +81,8 @@ describe('Given AuthoritiesSearch', () => {
   it('should display dropdown with searchable indexes', () => {
     const { getByText } = renderAuthoritiesSearch();
 
-    Object.values(searchableIndexesValues).forEach(indexValue => {
-      expect(getByText(`ui-marc-authorities.${indexValue}`)).toBeDefined();
+    rawSearchableIndexes.forEach(({ label }) => {
+      expect(getByText(label)).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Description
Fix name of `Identifiers (all)` search option. Fix error when url contains invalid search index name

## Issues
[UIMARCAUTH-46](https://issues.folio.org/browse/UIMARCAUTH-46)

## Screenshots
![MARC Authority - FOLIO (1)](https://user-images.githubusercontent.com/19309423/148217507-e6d42aa4-a655-4457-8e2b-6bf27de765f1.gif)

