### PR TITLE
UIMARCAUTH-37: Fix Closing third pane does not resize the second pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * New app created with stripes-cli
 * [UIMARCAUTH-6](https://issues.folio.org/browse/UIMARCAUTH-6) Add View MARC authority record permission.
 * [UIMARCAUTH-5](https://issues.folio.org/browse/UIMARCAUTH-5) Add Edit MARC authority record permission.
+* [UIMARCAUTH-18](https://issues.folio.org/browse/UIMARCAUTH-18) Display Results List.
 * [UIMARCAUTH-16](https://issues.folio.org/browse/UIMARCAUTH-16) Implement MARC Authorities Search Box.
 * [UIMARCAUTH-3](https://issues.folio.org/browse/UIMARCAUTH-3) Add View MARC authority record in MARC Authorities App.
 * [UIMARCAUTH-20](https://issues.folio.org/browse/UIMARCAUTH-20) Implement Results List Column Chooser.
@@ -19,4 +20,5 @@
 * [UIMARCAUTH-32](https://issues.folio.org/browse/UIMARCAUTH-32) Search box - Hit enter key must run search.
 * [UIMARCAUTH-36](https://issues.folio.org/browse/UIMARCAUTH-36) Update second line heading on QuickMarc view pane.
 * [UIMARCAUTH-45](https://issues.folio.org/browse/UIMARCAUTH-45) Add Edit button on MarcView Pane.
-* [UIMARCAUTH-46](https://issues.folio.org/browse/UIMARCAUTH-46) Fix Cannot get Authority record search - Identifiers search option to work
+* [UIMARCAUTH-46](https://issues.folio.org/browse/UIMARCAUTH-46) Fix Cannot get Authority record search - Identifiers search option to work.
+* [UIMARCAUTH-37](https://issues.folio.org/browse/UIMARCAUTH-37) Fix Closing third pane does not resize the second pane size and Reset all does not reset results list pane.

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -127,6 +127,7 @@ const SearchResultsList = ({
       sortedColumn={sortedColumn}
       sortOrder={sortOrder}
       onHeaderClick={onHeaderClick}
+      autosize
       isEmptyMessage={
         source ? (
           <div data-test-agreements-no-results-message>

--- a/src/components/SearchResultsList/SearchResultsList.test.js
+++ b/src/components/SearchResultsList/SearchResultsList.test.js
@@ -3,6 +3,7 @@ import {
 } from '@testing-library/react';
 import noop from 'lodash/noop';
 
+import { mockOffsetSize } from '@folio/stripes-acq-components/test/jest/helpers/mockOffsetSize';
 import Harness from '../../../test/jest/helpers/harness';
 import SearchResultsList from './SearchResultsList';
 import authorities from '../../../mocks/authorities';
@@ -35,6 +36,8 @@ const renderSearchResultsList = (props = {}) => render(
 );
 
 describe('Given SearchResultsList', () => {
+  mockOffsetSize(500, 500);
+
   it('should render MCL component', async () => {
     const { getAllByText } = renderSearchResultsList();
 

--- a/src/components/SearchResultsList/SearchResultsList.test.js
+++ b/src/components/SearchResultsList/SearchResultsList.test.js
@@ -4,6 +4,7 @@ import {
 import noop from 'lodash/noop';
 
 import { mockOffsetSize } from '@folio/stripes-acq-components/test/jest/helpers/mockOffsetSize';
+
 import Harness from '../../../test/jest/helpers/harness';
 import SearchResultsList from './SearchResultsList';
 import authorities from '../../../mocks/authorities';

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -154,7 +154,7 @@ const AuthoritiesSearch = ({ children }) => {
     const searchString = `${buildSearch(queryParams)}`;
 
     history.replace({
-      pathname: location.pathname,
+      pathname: '/marc-authorities',
       search: searchString,
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -363,6 +363,8 @@ const AuthoritiesSearch = ({ children }) => {
         )}
         firstMenu={renderResultsFirstMenu()}
         actionMenu={renderActionMenu}
+        padContent={false}
+        noOverflow
       >
         <SearchResultsList
           authorities={authorities}

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   useHistory,
@@ -36,9 +37,16 @@ const AuthorityView = ({
   const history = useHistory();
   const location = useLocation();
 
-  const onClose = () => {
-    history.push('/marc-authorities');
-  };
+  const onClose = useCallback(
+    () => {
+      history.push({
+        pathname: '/marc-authorities',
+        search: location.search,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location.search],
+  );
 
   if (marcSource.isLoading || authority.isLoading) {
     return <LoadingView />;
@@ -60,6 +68,7 @@ const AuthorityView = ({
         heading: authority.data.headingType,
         lastUpdatedDate: intl.formatDate(marcSource.data.metadata.lastUpdatedDate),
       })}
+      isPaneset={false}
       marcTitle={intl.formatMessage({ id: 'ui-marc-authorities.marcHeading' })}
       marc={marcSource.data}
       onClose={onClose}


### PR DESCRIPTION
## Purpose
Fix closing third pane does not resize the second pane size and Reset all does not reset results list pane.

Changes is `ui-quick-marc` module were needed: [related PR](https://github.com/folio-org/ui-quick-marc/pull/255).

## Screenshots
![FkbhDgf8p7](https://user-images.githubusercontent.com/84023879/148377793-55b63112-62ee-480b-8138-b59c903eb922.gif)

### Code coverage
![image](https://user-images.githubusercontent.com/84023879/148378756-77c1afeb-9eac-4b61-9e83-e63eac65efbe.png)
![image](https://user-images.githubusercontent.com/84023879/148378893-97a14604-06ae-4803-b479-66f331f29a25.png)
![image](https://user-images.githubusercontent.com/84023879/148378952-0f61efd1-562f-44d3-8a63-38cd257b1e09.png)

## Issues
[UIMARCAUTH-37](https://issues.folio.org/browse/UIMARCAUTH-37)
Related: [UIQM-195](https://issues.folio.org/browse/UIQM-195)