### PR TITLE
UIMARCAUTH-48: Extend request by searching by subjectHeadings = b when user selects Children's subject headings search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 * [UIMARCAUTH-45](https://issues.folio.org/browse/UIMARCAUTH-45) Add Edit button on MarcView Pane.
 * [UIMARCAUTH-46](https://issues.folio.org/browse/UIMARCAUTH-46) Fix Cannot get Authority record search - Identifiers search option to work.
 * [UIMARCAUTH-37](https://issues.folio.org/browse/UIMARCAUTH-37) Fix Closing third pane does not resize the second pane size and Reset all does not reset results list pane.
+* [UIMARCAUTH-48](https://issues.folio.org/browse/UIMARCAUTH-48) Children's subject headings search option - Extend request by searching by subjectHeadings = b.

--- a/src/queries/utils/buildQuery.js
+++ b/src/queries/utils/buildQuery.js
@@ -15,6 +15,12 @@ const buildQuery = ({
     return '';
   }
 
+  if (searchIndex === searchableIndexesValues.CHILDREN_SUBJECT_HEADING) {
+    const childrenSubjectHeadingData = indexData[0];
+
+    return `(${searchableIndexesValues.KEYWORD}=="%{query}" and ${childrenSubjectHeadingData.name}=="b")`;
+  }
+
   const queryStrings = indexData.map(data => {
     const queryParts = [];
 

--- a/src/queries/utils/buildQuery.test.js
+++ b/src/queries/utils/buildQuery.test.js
@@ -23,6 +23,16 @@ describe('Given buildQuery', () => {
     });
   });
 
+  describe('when non-existent index provided', () => {
+    it('should return an empty string', () => {
+      const query = buildQuery({
+        searchIndex: 'testIndex',
+      });
+
+      expect(query).toBe('');
+    });
+  });
+
   describe('when index with different names for plain, sft, and saft prefixes provided', () => {
     it('should return correct query', () => {
       const query = buildQuery({
@@ -40,6 +50,16 @@ describe('Given buildQuery', () => {
       });
 
       expect(query).toBe('(keyword=="%{query}")');
+    });
+  });
+
+  describe('when childrenSubjectHeading index provided', () => {
+    it('should return correct query for childrenSubjectHeading index', () => {
+      const query = buildQuery({
+        searchIndex: 'childrenSubjectHeading',
+      });
+
+      expect(query).toBe('(keyword=="%{query}" and subjectHeadings=="b")');
     });
   });
 });


### PR DESCRIPTION
## Purpose
Extend request by searching by subjectHeadings = b when user selects Children's subject headings search option.

Issue: [UIMARCAUTH-48](https://issues.folio.org/browse/UIMARCAUTH-48)