### PR TITLE
UIMARCAUTH-58: Request for Facets fails - missing permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * [UIMARCAUTH-28](https://issues.folio.org/browse/UIMARCAUTH-28) Browse MARC Authority Records > Display Browse headings toggle.
 * [UIMARCAUTH-52](https://issues.folio.org/browse/UIMARCAUTH-52) Update Keyword Search query to apply Exclude see also filter selection.
 * [UIMARCAUTH-60](https://issues.folio.org/browse/UIMARCAUTH-60) MARC authority record displays two different Last updated dates. 
+* [UIMARCAUTH-58](https://issues.folio.org/browse/UIMARCAUTH-58) Request for Facets fails - missing permissions.
+
 
 ## [0.1.0](https://github.com/folio-org/ui-marc-authorities/tree/v0.1.0) (2021-01-20)
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
         "subPermissions": [
           "module.marc-authorities.enabled",
           "records-editor.records.item.get",
-          "search.authorities.collection.get"
+          "search.authorities.collection.get",
+          "search.facets.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Description
Added access requires permission: search.facets.collection.get. 

## Issues
[UIMARCAUTH-58](https://issues.folio.org/browse/UIMARCAUTH-58)

