### PR TITLE
UIMARCAUTH-57: Cannot search by identifiers that contain a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 * [UIMARCAUTH-50](https://issues.folio.org/browse/UIMARCAUTH-50) Do not bold Auth/Ref in Authorized/Reference column.
 * [UIMARCAUTH-28](https://issues.folio.org/browse/UIMARCAUTH-28) Browse MARC Authority Records > Display Browse headings toggle.
 * [UIMARCAUTH-52](https://issues.folio.org/browse/UIMARCAUTH-52) Update Keyword Search query to apply Exclude see also filter selection.
-* [UIMARCAUTH-60](https://issues.folio.org/browse/UIMARCAUTH-60) MARC authority record displays two different Last updated dates. 
+* [UIMARCAUTH-60](https://issues.folio.org/browse/UIMARCAUTH-60) MARC authority record displays two different Last updated dates.
+* [UIMARCAUTH-57](https://issues.folio.org/browse/UIMARCAUTH-57) Fix cannot search by identifiers that contain a space.
 
 ## [0.1.0](https://github.com/folio-org/ui-marc-authorities/tree/v0.1.0) (2021-01-20)
 

--- a/src/queries/useAuthorities/useAuthorities.js
+++ b/src/queries/useAuthorities/useAuthorities.js
@@ -12,6 +12,7 @@ import { defaultAdvancedSearchQueryBuilder } from '@folio/stripes-components';
 import { buildQuery } from '../utils';
 import {
   filterConfig,
+  searchableIndexesValues,
 } from '../../constants';
 
 const AUTHORITIES_API = 'search/authorities';
@@ -25,10 +26,18 @@ const buildRegularSearch = (searchIndex, query, isExcludedSeeFromLimiter) => {
     { interpolate: /%{([\s\S]+?)}/g },
   );
 
-  const cqlSearch = query
-    ? query?.trim().split(/\s+/)
-      .map(q => compileQuery({ query: q }))
-    : [];
+  let cqlSearch = [];
+
+  if (query) {
+    if (searchIndex === searchableIndexesValues.IDENTIFIER) {
+      const compiledQuery = compileQuery({ query });
+
+      cqlSearch.push(compiledQuery);
+    } else {
+      cqlSearch = query?.trim().split(/\s+/)
+        .map(q => compileQuery({ query: q }));
+    }
+  }
 
   return cqlSearch;
 };

--- a/src/queries/useAuthorities/useAuthorities.test.js
+++ b/src/queries/useAuthorities/useAuthorities.test.js
@@ -61,7 +61,10 @@ describe('Given useAuthorities', () => {
     const isExcludedSeeFromLimiter = false;
     const pageSize = 20;
 
-    const { result, waitFor } = renderHook(() => useAuthorities({
+    const {
+      result,
+      waitFor,
+    } = renderHook(() => useAuthorities({
       searchQuery,
       searchIndex,
       filters,
@@ -79,7 +82,10 @@ describe('Given useAuthorities', () => {
   describe('when sort options are presented', () => {
     describe('when sort order is "descending"', () => {
       it('should add "sortBy authRefType/sort.descending" to query', async () => {
-        const { result, waitFor } = renderHook(() => useAuthorities({
+        const {
+          result,
+          waitFor,
+        } = renderHook(() => useAuthorities({
           searchQuery,
           searchIndex,
           filters: {},
@@ -95,7 +101,10 @@ describe('Given useAuthorities', () => {
 
     describe('when sort order is "descending"', () => {
       it('should add "sortBy authRefType/sort.ascending" to query', async () => {
-        const { result, waitFor } = renderHook(() => useAuthorities({
+        const {
+          result,
+          waitFor,
+        } = renderHook(() => useAuthorities({
           searchQuery,
           searchIndex,
           filters: {},
@@ -107,6 +116,70 @@ describe('Given useAuthorities', () => {
 
         expect(result.current.query).toEqual('(keyword=="test") sortBy authRefType/sort.ascending');
       });
+    });
+  });
+
+  describe('when query is not provided', () => {
+    it('should return an empty string', async () => {
+      const {
+        result,
+        waitFor,
+      } = renderHook(() => useAuthorities({
+        searchIndex,
+        filters: {},
+        isExcludedSeeFromLimiter: false,
+        sortOrder: '',
+        sortedColumn: '',
+      }), { wrapper });
+
+      await waitFor(() => !result.current.isLoading);
+
+      expect(result.current.query).toEqual('');
+    });
+  });
+
+  describe('when search by identifier', () => {
+    it('should return correct query string', async () => {
+      const {
+        result,
+        waitFor,
+      } = renderHook(() => useAuthorities({
+        searchQuery: 'n  00000001 ',
+        searchIndex: searchableIndexesValues.IDENTIFIER,
+        filters: {},
+        isExcludedSeeFromLimiter: false,
+        sortOrder: '',
+        sortedColumn: '',
+      }), { wrapper });
+
+      await waitFor(() => !result.current.isLoading);
+
+      expect(result.current.query).toEqual('(identifiers.value=="n  00000001 ")');
+    });
+  });
+
+  describe('when isAdvancedSearch prop is true', () => {
+    it('should form an advanced search query', async () => {
+      const { result } = renderHook(() => useAuthorities({
+        searchQuery,
+        searchIndex,
+        isAdvancedSearch: true,
+        advancedSearch: [{
+          bool: 'and',
+          query: 'advancedTest1',
+          searchOption: searchableIndexesValues.KEYWORD,
+        }, {
+          bool: 'not',
+          query: 'advancedTest2',
+          searchOption: searchableIndexesValues.IDENTIFIER,
+        }],
+        filters: {},
+        isExcludedSeeFromLimiter: false,
+        sortOrder: '',
+        sortedColumn: '',
+      }), { wrapper });
+
+      expect(result.current.query).toEqual('(keyword=="advancedTest1") not (identifiers.value=="advancedTest2")');
     });
   });
 });

--- a/src/queries/utils/buildQuery.js
+++ b/src/queries/utils/buildQuery.js
@@ -5,6 +5,11 @@ import {
   searchableIndexesMap,
 } from '../../constants';
 
+const indexesWithSpecialExcludeSeeFromLimiterQuery = [
+  searchableIndexesValues.KEYWORD,
+  searchableIndexesValues.IDENTIFIER,
+];
+
 const buildQuery = ({
   searchIndex,
   comparator = '==',
@@ -35,8 +40,8 @@ const buildQuery = ({
     }
 
     if (isExcludedSeeFromLimiter) {
-      if (searchIndex === searchableIndexesValues.KEYWORD) {
-        return [`${searchableIndexesValues.KEYWORD}=="%{query}" and authRefType == "Authorized"`];
+      if (indexesWithSpecialExcludeSeeFromLimiterQuery.some(index => index === searchIndex)) {
+        return [`${searchIndex}=="%{query}" and authRefType == "Authorized"`];
       }
 
       return queryParts;

--- a/src/queries/utils/buildQuery.test.js
+++ b/src/queries/utils/buildQuery.test.js
@@ -2,17 +2,6 @@ import buildQuery from './buildQuery';
 import { searchableIndexesValues } from '../../constants';
 
 describe('Given buildQuery', () => {
-  describe('when index without any prefix provided', () => {
-    it('should return correct query', () => {
-      const query = buildQuery({
-        searchIndex: searchableIndexesValues.IDENTIFIER,
-        isExcludedSeeFromLimiter: true,
-      });
-
-      expect(query).toBe('(identifiers.value=="%{query}")');
-    });
-  });
-
   describe('when index with plain, sft, and saft prefixes provided', () => {
     it('should return correct query', () => {
       const query = buildQuery({
@@ -20,6 +9,17 @@ describe('Given buildQuery', () => {
       });
 
       expect(query).toBe('(personalName=="%{query}" or sftPersonalName=="%{query}" or saftPersonalName=="%{query}")');
+    });
+
+    describe('when isExcludedSeeFromLimiter is true', () => {
+      it('should return correct query', () => {
+        const query = buildQuery({
+          searchIndex: searchableIndexesValues.PERSONAL_NAME,
+          isExcludedSeeFromLimiter: true,
+        });
+
+        expect(query).toBe('(personalName=="%{query}")');
+      });
     });
   });
 
@@ -44,7 +44,7 @@ describe('Given buildQuery', () => {
   });
 
   describe('when keyword index provided', () => {
-    it('should return correct query for keyword index', () => {
+    it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: searchableIndexesValues.KEYWORD,
       });
@@ -64,10 +64,31 @@ describe('Given buildQuery', () => {
     });
   });
 
-  describe('when childrenSubjectHeading index provided', () => {
-    it('should return correct query for childrenSubjectHeading index', () => {
+  describe('when identifier index provided', () => {
+    it('should return correct query', () => {
       const query = buildQuery({
-        searchIndex: searchableIndexesValues.CHILDREN_SUBJECT_HEADING,
+        searchIndex: searchableIndexesValues.IDENTIFIER,
+      });
+
+      expect(query).toBe('(identifiers.value=="%{query}")');
+    });
+
+    describe('when isExcludedSeeFromLimiter is true', () => {
+      it('should return correct query', () => {
+        const query = buildQuery({
+          searchIndex: searchableIndexesValues.IDENTIFIER,
+          isExcludedSeeFromLimiter: true,
+        });
+
+        expect(query).toBe('(identifiers.value=="%{query}" and authRefType == "Authorized")');
+      });
+    });
+  });
+
+  describe('when childrenSubjectHeading index provided', () => {
+    it('should return correct query', () => {
+      const query = buildQuery({
+        searchIndex: 'childrenSubjectHeading',
       });
 
       expect(query).toBe('(keyword=="%{query}" and subjectHeadings=="b")');


### PR DESCRIPTION
## Purpose
Fix cannot search by identifiers that contain a space.

## Screenshots
![9E5wdfO0tp](https://user-images.githubusercontent.com/84023879/152334417-9da89519-13e2-4b19-9b92-e155a984d3fe.gif)

## Issues
[UIMARCAUTH-57](https://issues.folio.org/browse/UIMARCAUTH-57)
