### PR TITLE
UIMARCAUTH-62: Create a Subject heading/thesaurus facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [UIMARCAUTH-73](https://issues.folio.org/browse/UIMARCAUTH-73) Update Authority Search Options - Corporate/Conference Name & Personal Name.
 * [UIMARCAUTH-76](https://issues.folio.org/browse/UIMARCAUTH-65) Change query in Geographic name search option.
 * [UIMARCAUTH-70](https://issues.folio.org/browse/UIMARCAUTH-70) Clicking on Result in Results list should highlight the selected row.
+* [UIMARCAUTH-62](https://issues.folio.org/browse/UIMARCAUTH-62) Create a Subject heading/thesaurus facet.
 
 ## [0.1.0](https://github.com/folio-org/ui-marc-authorities/tree/v0.1.0) (2021-01-20)
 

--- a/src/components/AuthoritiesSearchForm/AuthoritiesSearchForm.js
+++ b/src/components/AuthoritiesSearchForm/AuthoritiesSearchForm.js
@@ -53,6 +53,7 @@ const AuthoritiesSearchForm = ({
 
   const {
     navigationSegmentValue,
+    filters,
     searchDropdownValue,
     searchInputValue,
     setSearchInputValue,
@@ -113,6 +114,9 @@ const AuthoritiesSearchForm = ({
     || !searchInputValue
     || isAuthoritiesLoading;
 
+  const isFiltersApplied = Object.values(filters).find(value => value.length > 0);
+  const isResetAllButtonDisabled = (!searchInputValue && !isFiltersApplied) || isAuthoritiesLoading;
+
   return (
     <form onSubmit={onSubmitSearch}>
       <FilterNavigation />
@@ -154,7 +158,7 @@ const AuthoritiesSearchForm = ({
                 buttonStyle="none"
                 id="clickable-reset-all"
                 fullWidth
-                disabled={!searchInputValue || isAuthoritiesLoading}
+                disabled={isResetAllButtonDisabled}
                 onClick={() => {
                   resetRows();
                   handleResetAll();

--- a/src/components/AuthoritiesSearchForm/AuthoritiesSearchForm.test.js
+++ b/src/components/AuthoritiesSearchForm/AuthoritiesSearchForm.test.js
@@ -191,9 +191,7 @@ describe('Given AuthoritiesSearchForm', () => {
 
       expect(textarea.value).toBe('');
     });
-  });
 
-  describe('when textarea is not empty and Reset all button is clicked', () => {
     it('should handle setSelectedAuthorityRecordContext', () => {
       const {
         getByRole,

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -19,12 +19,12 @@ import { MultiSelectionFacet } from '../MultiSelectionFacet';
 import { useSectionToggle } from '../../hooks';
 import { useFacets } from '../../queries';
 
-import { navigationSegments } from '../../constants';
+import {
+  navigationSegments,
+  facetsTypes,
+  subjectHeadingsMap,
+} from '../../constants';
 import { AuthoritiesSearchContext } from '../../context';
-
-const FACETS = {
-  HEADING_TYPE: 'headingType',
-};
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -49,7 +49,8 @@ const SearchFilters = ({
   const isSearchNavigationSegment = navigationSegmentValue === navigationSegments.search;
 
   const [filterAccordions, { handleSectionToggle }] = useSectionToggle({
-    [FACETS.HEADING_TYPE]: false,
+    [facetsTypes.HEADING_TYPE]: false,
+    [facetsTypes.SUBJECT_HEADINGS]: false,
   });
 
   const selectedFacets = Object.keys(filterAccordions).filter(accordion => filterAccordions[accordion]);
@@ -77,6 +78,19 @@ const SearchFilters = ({
     setIsExcludedSeeFromLimiter(isExcluded => !isExcluded);
   };
 
+  const getSubjectHeadingsFacetOptions = () => {
+    return facets[facetsTypes.SUBJECT_HEADINGS]?.values.map(value => {
+      const subjectHeadingsName = Object.keys(subjectHeadingsMap).find(key => {
+        return subjectHeadingsMap[key] === value.id;
+      });
+
+      return {
+        id: subjectHeadingsName,
+        totalRecords: value.totalRecords,
+      };
+    });
+  };
+
   return (
     <>
       <Accordion
@@ -101,15 +115,29 @@ const SearchFilters = ({
       {isSearchNavigationSegment && (
         <>
           <MultiSelectionFacet
-            id={FACETS.HEADING_TYPE}
-            label={intl.formatMessage({ id: `ui-marc-authorities.search.${FACETS.HEADING_TYPE}` })}
-            name={FACETS.HEADING_TYPE}
-            open={filterAccordions[FACETS.HEADING_TYPE]}
-            options={facets[FACETS.HEADING_TYPE]?.values || []}
-            selectedValues={filters[FACETS.HEADING_TYPE]}
+            id={facetsTypes.SUBJECT_HEADINGS}
+            label={intl.formatMessage({ id: `ui-marc-authorities.search.${facetsTypes.SUBJECT_HEADINGS}` })}
+            name={facetsTypes.SUBJECT_HEADINGS}
+            open={filterAccordions[facetsTypes.SUBJECT_HEADINGS]}
+            options={getSubjectHeadingsFacetOptions() || []}
+            selectedValues={filters[facetsTypes.SUBJECT_HEADINGS]}
             onFilterChange={applyFilters}
             onClearFilter={onClearFilter}
-            displayClearButton={!!filters[FACETS.HEADING_TYPE]}
+            displayClearButton={!!filters[facetsTypes.SUBJECT_HEADINGS]?.length}
+            handleSectionToggle={handleSectionToggle}
+            isPending={isLoading}
+          />
+
+          <MultiSelectionFacet
+            id={facetsTypes.HEADING_TYPE}
+            label={intl.formatMessage({ id: `ui-marc-authorities.search.${facetsTypes.HEADING_TYPE}` })}
+            name={facetsTypes.HEADING_TYPE}
+            open={filterAccordions[facetsTypes.HEADING_TYPE]}
+            options={facets[facetsTypes.HEADING_TYPE]?.values || []}
+            selectedValues={filters[facetsTypes.HEADING_TYPE]}
+            onFilterChange={applyFilters}
+            onClearFilter={onClearFilter}
+            displayClearButton={!!filters[facetsTypes.HEADING_TYPE]?.length}
             handleSectionToggle={handleSectionToggle}
             isPending={isLoading}
           />

--- a/src/components/SearchFilters/SearchFilters.test.js
+++ b/src/components/SearchFilters/SearchFilters.test.js
@@ -9,6 +9,21 @@ import SearchFilters from './SearchFilters';
 import Harness from '../../../test/jest/helpers/harness';
 import { navigationSegments } from '../../constants';
 
+jest.mock('../../queries', () => ({
+  ...jest.requireActual('../../queries'),
+  useFacets: jest.fn().mockReturnValue({
+    isLoading: false,
+    facets: {
+      subjectHeadings: {
+        values: [{
+          id: 'a',
+          totalRecords: 10,
+        }],
+      },
+    },
+  }),
+}));
+
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   AcqDateRangeFilter: ({ name }) => <div>{name}</div>,
@@ -31,6 +46,7 @@ const defaultCtxValue = {
   setFilters: mockSetFilters,
   filters: {
     headingType: ['val-a', 'val-b'],
+    subjectHeadings: ['Other'],
   },
   isExcludedSeeFromLimiter: false,
   navigationSegmentValue: navigationSegments.search,
@@ -53,6 +69,12 @@ describe('Given SearchFilters', () => {
     const { getByText } = renderSearchFilters();
 
     expect(getByText('headingType')).toBeDefined();
+  });
+
+  it('should render Subject heading/thesaurus filter', () => {
+    const { getByText } = renderSearchFilters();
+
+    expect(getByText('subjectHeadings')).toBeDefined();
   });
 
   it('should display "References" accordion and "Exclude see from" checkbox', () => {

--- a/src/constants/facetsTypes.js
+++ b/src/constants/facetsTypes.js
@@ -1,0 +1,4 @@
+export const facetsTypes = {
+  HEADING_TYPE: 'headingType',
+  SUBJECT_HEADINGS: 'subjectHeadings',
+};

--- a/src/constants/filterConfig/filterConfig.js
+++ b/src/constants/filterConfig/filterConfig.js
@@ -17,4 +17,12 @@ export const filterConfig = [
       return `(headingType==(${valuesInQuotes}))`;
     },
   },
+  {
+    name: 'subjectHeadings',
+    parse: (values) => {
+      const valuesInQuotes = values.map(value => `"${value}"`).join(' or ');
+
+      return `(subjectHeadings==(${valuesInQuotes}))`;
+    },
+  },
 ];

--- a/src/constants/filterConfig/filterConfig.test.js
+++ b/src/constants/filterConfig/filterConfig.test.js
@@ -30,4 +30,14 @@ describe('filterConfig', () => {
       expect(searchString).toEqual('(headingType==("val1" or "val2"))');
     });
   });
+
+  describe('subjectHeadings filter', () => {
+    it('should return correct search string', () => {
+      const filter = filterConfig.find(config => config.name === 'subjectHeadings');
+
+      const searchString = filter.parse(['val1', 'val2']);
+
+      expect(searchString).toEqual('(subjectHeadings==("val1" or "val2"))');
+    });
+  });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -6,3 +6,6 @@ export * from './searchResultsListColumns';
 export * from './filterConfig';
 export * from './sortOrders';
 export * from './navigationSegments';
+export * from './subjectHeadingsValues';
+export * from './subjectHeadingsMap';
+export * from './facetsTypes';

--- a/src/constants/subjectHeadingsMap.js
+++ b/src/constants/subjectHeadingsMap.js
@@ -1,0 +1,15 @@
+import { subjectHeadingsValues } from './subjectHeadingsValues';
+
+export const subjectHeadingsMap = {
+  [subjectHeadingsValues.LIBRARY_OF_CONGRESS]: 'a',
+  [subjectHeadingsValues.LC_FOR_CHILDRENS_LITERATURE]: 'b',
+  [subjectHeadingsValues.MEDICAL]: 'c',
+  [subjectHeadingsValues.NATIONAL_AGRICULTURE_LIBRARY]: 'd',
+  [subjectHeadingsValues.CANADIAN]: 'k',
+  [subjectHeadingsValues.NOT_APPLICABLE]: 'n',
+  [subjectHeadingsValues.ART_AND_ARCHITECTURE]: 'r',
+  [subjectHeadingsValues.SEARS_LIST]: 's',
+  [subjectHeadingsValues.REPERTOIRE_DE_VEDETTES_MATIERE]: 'v',
+  [subjectHeadingsValues.OTHER]: 'z',
+  [subjectHeadingsValues.NOT_SPECIFIED]: ' ',
+};

--- a/src/constants/subjectHeadingsValues.js
+++ b/src/constants/subjectHeadingsValues.js
@@ -1,0 +1,13 @@
+export const subjectHeadingsValues = {
+  LIBRARY_OF_CONGRESS: 'Library of Congress Subject Headings',
+  LC_FOR_CHILDRENS_LITERATURE: 'LC subject headings for children\'s literature',
+  MEDICAL: 'Medical Subject Headings',
+  NATIONAL_AGRICULTURE_LIBRARY: 'National Agricultural Library subject authority file',
+  CANADIAN: 'Canadian Subject Headings',
+  NOT_APPLICABLE: 'Not applicable',
+  ART_AND_ARCHITECTURE: 'Art and Architecture Thesaurus',
+  SEARS_LIST: 'Sears List of Subject Headings',
+  REPERTOIRE_DE_VEDETTES_MATIERE: 'Répertoire de vedettes-matière',
+  OTHER: 'Other',
+  NOT_SPECIFIED: 'Not specified',
+};

--- a/src/queries/useAuthorities/useAuthorities.js
+++ b/src/queries/useAuthorities/useAuthorities.js
@@ -15,7 +15,9 @@ import { defaultAdvancedSearchQueryBuilder } from '@folio/stripes-components';
 import { buildQuery } from '../utils';
 import {
   filterConfig,
+  facetsTypes,
   searchableIndexesValues,
+  subjectHeadingsMap,
 } from '../../constants';
 
 const AUTHORITIES_API = 'search/authorities';
@@ -103,7 +105,15 @@ const useAuthorities = ({
     .map(([filterName, filterValues]) => {
       const filterData = filterConfig.find(filter => filter.name === filterName);
 
-      return filterData.parse(filterValues);
+      let finalFilterValues = filterValues;
+
+      if (filterName === facetsTypes.SUBJECT_HEADINGS) {
+        const filterValuesForSubjectHeadings = filterValues.map(name => subjectHeadingsMap[name]);
+
+        finalFilterValues = filterValuesForSubjectHeadings;
+      }
+
+      return filterData.parse(finalFilterValues);
     });
 
   let cqlQuery = [...cqlSearch, ...cqlFilters].join(' and ');
@@ -133,7 +143,7 @@ const useAuthorities = ({
   } = useQuery(
     [namespace, searchParams],
     async () => {
-      if (!searchQuery && Object.keys(filters).length === 0) {
+      if (!searchQuery && !Object.values(filters).find(value => value.length > 0)) {
         return { authorities: [], totalRecords: 0 };
       }
 

--- a/src/queries/useAuthorities/useAuthorities.test.js
+++ b/src/queries/useAuthorities/useAuthorities.test.js
@@ -48,6 +48,7 @@ describe('Given useAuthorities', () => {
   it('fetches authorities records', async () => {
     const filters = {
       updatedDate: ['2021-01-01:2021-12-31'],
+      subjectHeadings: ['Other'],
     };
     const isExcludedSeeFromLimiter = false;
     const pageSize = 20;

--- a/src/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/src/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -12,7 +12,6 @@ import {
   useNamespace,
 } from '@folio/stripes/core';
 
-import { useDidUpdate } from '../../hooks';
 import { searchableIndexesValues } from '../../constants';
 
 const AUTHORITIES_BROWSE_API = 'browse/authorities';

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -17,6 +17,7 @@
   "search.searchAndFilter": "Search & filter",
   "search.createdDate": "Date created",
   "search.updatedDate": "Date updated",
+  "search.subjectHeadings": "Subject heading/thesaurus",
   "search.headingType": "Type of heading",
   "search.references": "References",
   "search.excludeSeeFrom": "Exclude see from",


### PR DESCRIPTION
## Description
In scope of this task the following have been done:

- **Create a Subject heading/thesaurus facet.**
- **Fix an error request which was being sent when unselect last facet option.** 
   It happened because `filters` object was not set to empty in such case, but just set to empty an array of facet's values. For example:
  ```
  filters: {
    subjectHeadings: [],
  }
  ```
   But there was check for an absence of object's keys, which didn't pass, so it had to be replaced with check for an empty arrays of object's values.
- **Hide clear facet button when unselect last facet option.**
- **Enable Reset all button when any filter is applied.**

## Screenshots
![chrome_sg9Wga1oTs](https://user-images.githubusercontent.com/84023879/155016897-c9b3489a-b49b-47a1-8389-43a3ca9c96c7.gif)

## Issues
[UIMARCAUTH-62](https://issues.folio.org/browse/UIMARCAUTH-62)