### PR TITLE
UIMARCAUTH-108: Cannot assign MARC authority permissions only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.1.0](IN PROGRESS)
 * [UIMARCAUTH-92](https://issues.folio.org/browse/UIMARCAUTH-92) Change MARC Authority in universal header Apps dropdown and app context menu dropdown.
+* [UIMARCAUTH-108](https://issues.folio.org/browse/UIMARCAUTH-108) Cannot assign MARC authority permissions only.
 
 ## [1.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.1) (2022-03-21)
 * [UIMARCAUTH-89](https://issues.folio.org/browse/UIMARCAUTH-89) Browse option selection searches all.

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
           "records-editor.records.item.get",
           "search.authorities.collection.get",
           "search.facets.collection.get",
-          "source-storage.records.get"
+          "source-storage.records.get",
+          "inventory-storage.authorities.item.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
# Description
added subPermissions as "inventory-storage.authorities.item.get"  in package.json

## Issues
[UIMARCAUTH-108](https://issues.folio.org/browse/UIMARCAUTH-108)
