### PR TITLE
UIMARCAUTH-112 Rename Subject heading/thesaurus facet to Thesaurus facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [UIMARCAUTH-100](https://issues.folio.org/browse/UIMARCAUTH-100) Fix tag value which contains part of authority heading ref value gets highlighted at record detail view.
 * [UIMARCAUTH-75](https://issues.folio.org/browse/UIMARCAUTH-75) Searching MARC authority records: Split up Exclude See from filters into two filters.
 * [UIMARCAUTH-110](https://issues.folio.org/browse/UIMARCAUTH-110) When searching Identifier (all) search option Then only return results with Authorized/Reference type = Authorized.
+* [UIMARCAUTH-112](https://issues.folio.org/browse/UIMARCAUTH-112) Renamed accordion label and facet label from Subject heading/thesaurus facet to Thesaurus facet
 
 ## [1.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.1) (2022-03-21)
 * [UIMARCAUTH-89](https://issues.folio.org/browse/UIMARCAUTH-89) Browse option selection searches all.

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -17,7 +17,7 @@
   "search.searchAndFilter": "Search & filter",
   "search.createdDate": "Date created",
   "search.updatedDate": "Date updated",
-  "search.subjectHeadings": "Subject heading/thesaurus",
+  "search.subjectHeadings": "Thesaurus",
   "search.headingType": "Type of heading",
   "search.references": "References",
   "search.excludeSeeFrom": "Exclude see from",


### PR DESCRIPTION
## Description
Renamed the Accordion label and facet label from Subject heading/thesaurus to Thesaurus

## Approach
Changed "search.subjectHeadings" property inside translations/en.json file

## Screenshots
![image](https://user-images.githubusercontent.com/101391438/160368922-ed6a7910-7ae7-4bc0-b2dc-61ad7373d84d.png)

## Issue
[UIMARCAUTH-112](https://issues.folio.org/browse/UIMARCAUTH-112)