### PR TITLE
"UIMARCAUTH-111: If only one result is returned then automatically display detail record"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIMARCAUTH-75](https://issues.folio.org/browse/UIMARCAUTH-75) Searching MARC authority records: Split up Exclude See from filters into two filters.
 * [UIMARCAUTH-110](https://issues.folio.org/browse/UIMARCAUTH-110) When searching Identifier (all) search option Then only return results with Authorized/Reference type = Authorized.
 * [UIMARCAUTH-112](https://issues.folio.org/browse/UIMARCAUTH-112) Renamed accordion label and facet label from Subject heading/thesaurus facet to Thesaurus facet
+* [UIMARCAUTH-111](https://issues.folio.org/browse/UIMARCAUTH-111) If only one result is returned then automatically display detail record.
 
 ## [1.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.1) (2022-03-21)
 * [UIMARCAUTH-89](https://issues.folio.org/browse/UIMARCAUTH-89) Browse option selection searches all.

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -1,12 +1,14 @@
 import {
   useMemo,
   useContext,
+  useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import {
   useRouteMatch,
   useLocation,
+  useHistory,
 } from 'react-router';
 import queryString from 'query-string';
 
@@ -64,6 +66,7 @@ const SearchResultsList = ({
   const intl = useIntl();
   const match = useRouteMatch();
   const location = useLocation();
+  const history = useHistory();
 
   const [selectedAuthorityRecordContext, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
@@ -89,6 +92,12 @@ const SearchResultsList = ({
 
     return `${match.path}/authorities/${authority.id}?${newSearch}`;
   };
+
+   useEffect(() => {
+      if (totalResults === 1) {
+        history.push(formatAuthorityRecordLink(authorities[0]));
+      }
+    }, [totalResults, authorities[0]]);
 
   const formatter = {
     authRefType: (authority) => {

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -93,11 +93,11 @@ const SearchResultsList = ({
     return `${match.path}/authorities/${authority.id}?${newSearch}`;
   };
 
-   useEffect(() => {
-      if (totalResults === 1) {
-        history.push(formatAuthorityRecordLink(authorities[0]));
-      }
-    }, [totalResults, authorities[0]]);
+  useEffect(() => {
+    if (totalResults === 1) {
+      history.replace(formatAuthorityRecordLink(authorities[0]));
+    }
+  }, [totalResults, authorities[0]]);
 
   const formatter = {
     authRefType: (authority) => {

--- a/src/components/SearchResultsList/SearchResultsList.test.js
+++ b/src/components/SearchResultsList/SearchResultsList.test.js
@@ -16,6 +16,16 @@ import {
 
 const mockToggleFilterPane = jest.fn();
 const mockSetSelectedAuthorityRecordContext = jest.fn();
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+  useLocation: jest.fn().mockReturnValue({ search: '' }),
+  useRouteMatch: jest.fn().mockReturnValue({ path: '' }),
+}));
 
 const renderSearchResultsList = (props = {}) => render(
   <Harness selectedRecordCtxValue={[null, mockSetSelectedAuthorityRecordContext]}>
@@ -166,6 +176,28 @@ describe('Given SearchResultsList', () => {
       });
 
       expect(getByText('ui-marc-authorities.browse.noMatch.wouldBeHereLabel')).toBeDefined();
+    });
+  });
+
+  describe('When there is only one record', () => {
+    afterAll(() => {
+      jest.resetAllMocks();
+    });
+    it('Should call history.replace with specefic params', () => {
+      renderSearchResultsList({
+        authorities: [
+          {
+            id: 'cbc03a36-2870-4184-9777-0c44d07edfe4',
+            headingType: 'Geographic Name',
+            authRefType: 'Authorized',
+            headingRef: 'Springfield (Colo.)',
+          },
+        ],
+        totalResults: 1,
+      });
+      expect(mockHistoryReplace).toHaveBeenCalledWith(
+        '/authorities/cbc03a36-2870-4184-9777-0c44d07edfe4?authRefType=Authorized&headingRef=Springfield%20%28Colo.%29',
+      );
     });
   });
 });

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -4,7 +4,6 @@ import {
   useContext,
 } from 'react';
 import {
-  useHistory,
   useLocation,
 } from 'react-router-dom';
 import {
@@ -35,7 +34,6 @@ import {
   AppIcon,
   useNamespace,
 } from '@folio/stripes/core';
-import { buildSearch } from '@folio/stripes-acq-components';
 
 import {
   SearchResultsList,
@@ -89,7 +87,6 @@ const AuthoritiesSearch = ({
   const intl = useIntl();
   const [, getNamespace] = useNamespace();
 
-  const history = useHistory();
   const location = useLocation();
 
   const {
@@ -133,20 +130,10 @@ const AuthoritiesSearch = ({
       queryParams.sort = `${order}${sortedColumn}`;
     }
 
-    const searchString = `${buildSearch(queryParams)}`;
-
-    const pathname = isGoingToBaseURL
-      ? '/marc-authorities'
-      : location.pathname;
-
     if (isGoingToBaseURL) {
       setIsGoingToBaseURL(false);
     }
 
-    history.replace({
-      pathname,
-      search: searchString,
-    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     searchQuery,


### PR DESCRIPTION
## Description
If there is only one search result, we are displaying the detail record without letting user click on the result.

## Approach
SearchResultList component is getting totalResults and authorities(results) as props, I have used a useEffect hook which is checking if the totalResults property is one, it will automatically take the result and open it. This is done by pushing the user to a url formed by formatAuthorityRecordLink function in the same component.

## Screenshots
https://user-images.githubusercontent.com/101391438/160613018-b23c0af1-934c-4d17-9070-f262c30f72e1.mp4

## Issue
[UIMARCAUTH-111](https://issues.folio.org/browse/UIMARCAUTH-111

