### PR TITLE
UIMARCAUTH-67 Permission: Delete MARC authority record - Made changes…

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       },
       {
         "permissionName": "ui-marc-authorities.authority-record.view",
-        "displayName": "View MARC authority record",
+        "displayName": "MARC Authority: View MARC authority record",
         "subPermissions": [
           "module.marc-authorities.enabled",
           "browse.authorities.collection.get",
@@ -116,7 +116,7 @@
       },
       {
         "permissionName": "ui-marc-authorities.authority-record.edit",
-        "displayName": "Edit MARC authority record",
+        "displayName": "MARC Authority: Edit MARC authority record",
         "subPermissions": [
           "ui-marc-authorities.authority-record.view",
           "records-editor.records.item.put"
@@ -125,7 +125,7 @@
       },
       {
         "permissionName": "ui-marc-authorities.authority-record.delete",
-        "displayName": "Delete MARC authority record",
+        "displayName": "MARC Authority: Delete MARC authority record",
         "subPermissions": [
           "records-editor.records.item.delete"
         ],


### PR DESCRIPTION
## Description
Permission: Delete MARC authority record | Made changes to the Display Names of the Permissions

## Approach
Added Delete MARC authority permission inside package.json file with permission name “ui-marc-authorities.authority-record.delete” and display name “MARC Authority: Delete MARC authority record”. Also added the translation inside en.json file. Also changed Display names of View MARC authority record & Edit MARC authority record.

## Issue
[UIMARCAUTH-67](https://issues.folio.org/browse/UIMARCAUTH-67)