### PR TITLE
UIMARCAUTH-122 correctly scroll the details pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [UIMARCAUTH-111](https://issues.folio.org/browse/UIMARCAUTH-111) If only one result is returned then automatically display detail record.
 - [UIMARCAUTH-67](https://issues.folio.org/browse/UIMARCAUTH-67) Permission: Delete MARC authority record.
 - [UIMARCAUTH-88](https://issues.folio.org/browse/UIMARCAUTH-88) Browse authorities: Add Heading type facet.
+- [UIMARCAUTH-122](https://issues.folio.org/browse/UIMARCAUTH-122) Correctly allow horizontal scrolling in details pane.
 
 ## [1.0.4](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.4) (2022-04-08)
 

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -135,7 +135,7 @@ const AuthorityView = ({
       canEdit={hasEditPermission()}
     >
       <MarcView
-        paneWidth="100%"
+        paneWidth="40%"
         paneTitle={authority.data.headingRef}
         paneSub={intl.formatMessage({
           id: 'ui-marc-authorities.authorityRecordSubtitle',

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -37,13 +37,13 @@ const propTypes = {
       headingRef: PropTypes.string,
       headingType: PropTypes.string,
       id: PropTypes.string,
-    }).isRequired,
+    }),
     isLoading: PropTypes.bool.isRequired,
   }).isRequired,
   marcSource: PropTypes.shape({
-    data: PropTypes.object.isRequired,
+    data: PropTypes.object,
     isLoading: PropTypes.bool.isRequired,
-  }).isRequired,
+  }),
 };
 
 const AuthorityView = ({
@@ -134,32 +134,31 @@ const AuthorityView = ({
       onEdit={redirectToQuickMarcEditPage}
       canEdit={hasEditPermission()}
     >
-      <div data-testid="authority-marc-view">
-        <MarcView
-          paneTitle={authority.data.headingRef}
-          paneSub={intl.formatMessage({
-            id: 'ui-marc-authorities.authorityRecordSubtitle',
-          }, {
-            heading: authority.data.headingType,
-            lastUpdatedDate: intl.formatDate(marcSource.data.metadata.updatedDate),
-          })}
-          isPaneset={false}
-          marcTitle={intl.formatMessage({ id: 'ui-marc-authorities.marcHeading' })}
-          marc={markHighlightedFields().data}
-          onClose={onClose}
-          lastMenu={(
-            <IfPermission perm="ui-marc-authorities.authority-record.edit">
-              <Button
-                buttonStyle="primary"
-                marginBottom0
-                onClick={redirectToQuickMarcEditPage}
-              >
-                <FormattedMessage id="ui-marc-authorities.authority-record.edit" />
-              </Button>
-            </IfPermission>
-           )}
-        />
-      </div>
+      <MarcView
+        paneWidth="100%"
+        paneTitle={authority.data.headingRef}
+        paneSub={intl.formatMessage({
+          id: 'ui-marc-authorities.authorityRecordSubtitle',
+        }, {
+          heading: authority.data.headingType,
+          lastUpdatedDate: intl.formatDate(marcSource.data.metadata.updatedDate),
+        })}
+        isPaneset={false}
+        marcTitle={intl.formatMessage({ id: 'ui-marc-authorities.marcHeading' })}
+        marc={markHighlightedFields().data}
+        onClose={onClose}
+        lastMenu={(
+          <IfPermission perm="ui-marc-authorities.authority-record.edit">
+            <Button
+              buttonStyle="primary"
+              marginBottom0
+              onClick={redirectToQuickMarcEditPage}
+            >
+              <FormattedMessage id="ui-marc-authorities.authority-record.edit" />
+            </Button>
+          </IfPermission>
+          )}
+      />
     </KeyShortCutsWrapper>
   );
 };

--- a/src/views/AuthorityView/AuthorityView.test.js
+++ b/src/views/AuthorityView/AuthorityView.test.js
@@ -237,12 +237,12 @@ describe('Given AuthorityView', () => {
         canEdit: canEditMock,
       });
 
-      const testDiv = getByTestId('authority-marc-view');
+      const testDiv = getByTestId('marc-view-pane');
 
       openEditShortcut(testDiv);
 
       expect(mockHistoryPush).toHaveBeenCalled();
-      expect(queryByTestId('authority-marc-view')).not.toBeNull();
+      expect(queryByTestId('marc-view-pane')).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
Clone of @zburke PR https://github.com/folio-org/ui-marc-authorities/pull/127

The only direct descendants of a <Paneset> should be <Pane>
components. Here, an extraneous <div> wrapper was inserted for the
purpose of providing a test hook. This change resolves the issue by
hooking directly onto the test-id of the inner <Pane>. This feels a
little risky since that test-id is not directly controlled by this
application.

A more thorough fix might be to allow the test-id in @folio/quick-marc
to be overridden by prop.

Refs [UIMARCAUTH-122](https://issues.folio.org/browse/UIMARCAUTH-122)