### PR TITLE
UIMARCAUTH-117 Resetting sort of search result list after editing 'MA…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-88](https://issues.folio.org/browse/UIMARCAUTH-88) Browse authorities: Add Heading type facet.
 - [UIMARCAUTH-64](https://issues.folio.org/browse/UIMARCAUTH-64) Add DELETE action for individual MARC Authority records.
 - [UIMARCAUTH-119](https://issues.folio.org/browse/UIMARCAUTH-119) Browse "Enter" run search when placeholder "Select a browse option" active
+- [UIMARCAUTH-117](https://issues.folio.org/browse/UIMARCAUTH-117) Resetting sort of search result list after editing "MARC Authority" record.
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/src/routes/SearchRoute/SearchRoute.js
+++ b/src/routes/SearchRoute/SearchRoute.js
@@ -87,6 +87,8 @@ const SearchRoute = ({ children }) => {
       onHeaderClick={onHeaderClick}
       onSubmitSearch={onSubmitSearch}
       handleLoadMore={handleLoadMore}
+      sortOrder={sortOrder}
+      sortedColumn={sortedColumn}
     >
       {children}
     </AuthoritiesSearch>


### PR DESCRIPTION
## Description
Resetting sort of search result list after editing "MARC Authority" record.

## Approach
Passed sortOrder and sortedColumn props to AuthoritiesSearch component. The component is adding sort property to the query parameters. Since it's part of the query parameters, the sorting values are retained on refresh.

## Issue
[UIMARCAUTH-117](https://issues.folio.org/browse/UIMARCAUTH-117)

## Screenshot

https://user-images.githubusercontent.com/101391438/163811237-aa96ede9-ad92-4727-be74-0c82312d0eaf.mp4
