### PR TITLE
UIMARCAUTH-132: Apply to MARC Authority: Optimistic locking: display …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [UIMARCAUTH-117](https://issues.folio.org/browse/UIMARCAUTH-117) Resetting sort of search result list after editing "MARC Authority" record.
 - [UIMARCAUTH-123](https://issues.folio.org/browse/UIMARCAUTH-123) Fix losing third pane after search and editing first result.
 - [UIMARCAUTH-125](https://issues.folio.org/browse/UIMARCAUTH-125) Replace `babel-eslint` with `@babel/eslint-parser`.
+- [UIMARCAUTH-132](https://issues.folio.org/browse/UIMARCAUTH-132) Apply to MARC Authority: Optimistic locking: display error message to inform user about OL.
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -114,9 +114,14 @@ const AuthorityView = ({
   }
 
   const redirectToQuickMarcEditPage = () => {
+    const searchParams = new URLSearchParams(location.search);
+
+    searchParams.delete('relatedRecordVersion');
+    searchParams.append('relatedRecordVersion', marcSource.data.generation);
+
     history.push({
       pathname: `/marc-authorities/quick-marc/edit-authority/${authority.data.id}`,
-      search: location.search,
+      search: searchParams.toString(),
     });
   };
 


### PR DESCRIPTION
## Description
Latest version added to the url when user editing a MARC authority record via quickMARC.

## Issues
[UIMARCAUTH-134](https://issues.folio.org/browse/UIMARCAUTH-134)

## Screenshots

https://user-images.githubusercontent.com/96055497/165786999-88890c21-1974-4b88-86f4-733b54a87442.mp4


