### PR TITLE
UIMARCAUTH-137: Modify MARC authority processing for delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@
 - [UIMARCAUTH-125](https://issues.folio.org/browse/UIMARCAUTH-125) Replace `babel-eslint` with `@babel/eslint-parser`.
 - [UIMARCAUTH-120](https://issues.folio.org/browse/UIMARCAUTH-120) Allow user to select MARC authority record(s) to export.
 - [UIMARCAUTH-132](https://issues.folio.org/browse/UIMARCAUTH-132) Apply to MARC Authority: Optimistic locking: display error message to inform user about OL.
-- [UIMARCAUTH-118](https://issues.folio.org/browse/UIMARCAUTH-118) Highlighting the row with "Heading/reference" value at result list after editing of record
-- [UIMARCAUTH-135](https://issues.folio.org/browse/UIMARCAUTH-135) The search result list doesn't sort by clicking on the title of column
-- [UIMARCAUTH-130](https://issues.folio.org/browse/UIMARCAUTH-130) Add a Select all/Un-select all on Results List
-- [UIMARCAUTH-121](https://issues.folio.org/browse/UIMARCAUTH-121) Export .csv file to load to Data export to create the .mrc file of selected authority records
+- [UIMARCAUTH-118](https://issues.folio.org/browse/UIMARCAUTH-118) Highlighting the row with "Heading/reference" value at result list after editing of record.
+- [UIMARCAUTH-135](https://issues.folio.org/browse/UIMARCAUTH-135) The search result list doesn't sort by clicking on the title of column.
+- [UIMARCAUTH-130](https://issues.folio.org/browse/UIMARCAUTH-130) Add a Select all/Un-select all on Results List.
+- [UIMARCAUTH-121](https://issues.folio.org/browse/UIMARCAUTH-121) Export .csv file to load to Data export to create the .mrc file of selected authority records.
+- [UIMARCAUTH-137](https://issues.folio.org/browse/UIMARCAUTH-137) Modify MARC authority processing for delete.
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/src/constants/deleteMarcAuthority.js
+++ b/src/constants/deleteMarcAuthority.js
@@ -1,0 +1,5 @@
+const MARC_RECORD_API = 'records-editor/records';
+
+export const MARC_RECORD_STATUS_API = `${MARC_RECORD_API}/status`;
+export const QM_RECORD_STATUS_TIMEOUT = 5000;
+export const QM_RECORD_STATUS_BAIL_TIME = 20000;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -15,3 +15,4 @@ export * from './subjectHeadingsValues';
 export * from './subjectHeadingsMap';
 export * from './queryKeys';
 export * from './exportAuthorityJobProfileId';
+export * from './deleteMarcAuthority';

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
@@ -2,25 +2,43 @@ import {
   useMutation,
   useQueryClient,
 } from 'react-query';
-
 import {
   useOkapiKy,
   useNamespace,
 } from '@folio/stripes/core';
 
-import { QUERY_KEY_AUTHORITIES } from '../../constants';
+import {
+  QUERY_KEY_AUTHORITIES,
+  MARC_RECORD_STATUS_API,
+  QM_RECORD_STATUS_TIMEOUT,
+  QM_RECORD_STATUS_BAIL_TIME,
+} from '../../constants';
 
 const useAuthorityDelete = ({ onError, onSuccess, ...restOptions }) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
   const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITIES });
 
+  const maxRequestAttempts = QM_RECORD_STATUS_BAIL_TIME / QM_RECORD_STATUS_TIMEOUT;
+  let requestCount = 1;
+
   const customOptions = {
     onError,
-    onSuccess: async () => {
-      // Creating a delay because result list takes some time to update
-      await new Promise((resolve) => setTimeout(resolve, 500));
+    onSuccess: async (deleteResult) => {
+      const { actionId } = await deleteResult.json();
+
+      let deleteRequestStatus;
+
+      while (deleteRequestStatus !== 'COMPLETED' && requestCount !== maxRequestAttempts) {
+        const statusResponse = await ky.get(MARC_RECORD_STATUS_API, { searchParams: { actionId } });
+        const { status } = statusResponse.json();
+
+        deleteRequestStatus = status;
+        requestCount++;
+      }
+
       queryClient.invalidateQueries(namespace);
+
       return onSuccess();
     },
   };

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
@@ -1,5 +1,11 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { renderHook, act } from '@testing-library/react-hooks';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import {
+  renderHook,
+  act,
+} from '@testing-library/react-hooks';
 import { useOkapiKy } from '@folio/stripes/core';
 
 import useAuthorityDelete from './useAuthorityDelete';
@@ -20,11 +26,13 @@ describe('useAuthorityDeleteMutation', () => {
   });
 
   it('should make delete request and call onSuccess', async () => {
-    const deleteMock = jest.fn().mockResolvedValue({});
+    const deleteMock = jest.fn().mockResolvedValue({ json: () => ({ actionId: 'actionId' }) });
+    const getMock = jest.fn().mockResolvedValue({ json: () => ({ status: 'COMPLETED' }) });
     const successMock = jest.fn();
 
     useOkapiKy.mockClear().mockReturnValue({
       delete: deleteMock,
+      get: getMock,
     });
 
     const { result, waitForNextUpdate } = renderHook(


### PR DESCRIPTION
## Purpose
Modify MARC authority processing for delete.

**Note:** Getting status after deleting MARC Authority record is not working properly now, so this functionality will be rechecked once that bug with getting status is resolved.

## Issues
[UIMARCAUTH-137](https://issues.folio.org/browse/UIMARCAUTH-137)