### PR TITLE
UIMARCAUTH-140 [Browse] The page without results is displayed when user go to the last page of result list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [UIMARCAUTH-121](https://issues.folio.org/browse/UIMARCAUTH-121) Export .csv file to load to Data export to create the .mrc file of selected authority records
 - [FOLIO-3477](https://issues.folio.org/browse/FOLIO-3477) FE: update outdated dependencies.
 - [UIMARCAUTH-143](https://issues.folio.org/browse/UIMARCAUTH-143) FE: Update Personal name, Corporate/Conference name and Corporate name Search/Browse options
+- [UIMARCAUTH-140](https://issues.folio.org/browse/UIMARCAUTH-140) [Browse] The page without results is displayed when user go to the last page of result list.
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },
+  "resolutions": {
+    "@vue/compiler-sfc": "3.2.33"
+  },
   "stripes": {
     "actsAs": [
       "app"

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -37,6 +37,8 @@ import css from './SearchResultsList.css';
 
 const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
+  hasNextPage: PropTypes.bool,
+  hasPrevPage: PropTypes.bool,
   hasFilters: PropTypes.bool.isRequired,
   hidePageIndices: PropTypes.bool,
   isFilterPaneVisible: PropTypes.bool.isRequired,
@@ -77,6 +79,8 @@ const SearchResultsList = ({
   selectAll,
   hasFilters,
   hidePageIndices,
+  hasNextPage,
+  hasPrevPage,
 }) => {
   const intl = useIntl();
   const match = useRouteMatch();
@@ -239,6 +243,8 @@ const SearchResultsList = ({
       onHeaderClick={onHeaderClick}
       autosize
       hidePageIndices={hidePageIndices}
+      canGoNext={hasNextPage}
+      canGoPrevious={hasPrevPage}
       isEmptyMessage={
         source
           ? (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -243,8 +243,8 @@ const SearchResultsList = ({
       onHeaderClick={onHeaderClick}
       autosize
       hidePageIndices={hidePageIndices}
-      canGoNext={hasNextPage}
-      canGoPrevious={hasPrevPage}
+      pagingCanGoNext={hasNextPage}
+      pagingCanGoPrevious={hasPrevPage}
       isEmptyMessage={
         source
           ? (

--- a/src/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/src/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -207,30 +207,15 @@ const useAuthoritiesBrowse = ({
     return (page === 0 && mainRequest.data?.totalRecords !== 0 && !!mainRequest.data?.items.find(item => !item.authority));
   }, [mainRequest.data, page]);
 
-  const itemsWithPrevAndNextPages = useMemo(() => {
+  const itemsWithoutEmptyHeadingRef = useMemo(() => {
     const authorities = [...(mainRequest.data?.items || [])];
 
     // remove item with an empty headingRef which appears
     // when apply Type of heading facet without search query
     remove(authorities, item => !item.authority && !item.headingRef);
 
-    if (allRequestsFetching) {
-      return authorities;
-    }
-
-    let totalItemsLength = mainRequest.data?.items?.length + prevPageRequest.data?.items?.length + nextPageRequest.data?.items?.length;
-
-    if (Number.isNaN(totalItemsLength)) {
-      totalItemsLength = 0;
-    }
-
-    const newItems = new Array(totalItemsLength);
-
-    newItems.splice(prevPageRequest.data?.items?.length, authorities.length, ...authorities);
-
-    return newItems;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mainRequest.data, allRequestsFetching]);
+    return authorities;
+  }, [mainRequest.data]);
 
   const handleLoadMore = (_askAmount, _index, _firstIndex, direction) => {
     if (direction === 'prev') { // clicked Prev
@@ -246,7 +231,9 @@ const useAuthoritiesBrowse = ({
 
   return ({
     totalRecords,
-    authorities: itemsWithPrevAndNextPages,
+    authorities: itemsWithoutEmptyHeadingRef,
+    hasPrevPage: !!prevPageRequest.data?.items?.length,
+    hasNextPage: !!nextPageRequest.data?.items?.length,
     isLoading: allRequestsFetching,
     isLoaded: allRequestsFetched,
     handleLoadMore,

--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -36,6 +36,8 @@ const BrowseRoute = ({ children }) => {
 
   const {
     authorities,
+    hasNextPage,
+    hasPrevPage,
     isLoading,
     isLoaded,
     handleLoadMore,
@@ -78,6 +80,8 @@ const BrowseRoute = ({ children }) => {
   return (
     <AuthoritiesSearch
       authorities={formattedAuthoritiesForView}
+      hasNextPage={hasNextPage}
+      hasPrevPage={hasPrevPage}
       totalRecords={totalRecords}
       isLoading={isLoading}
       isLoaded={isLoaded}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -69,6 +69,8 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
   handleLoadMore: PropTypes.func.isRequired,
+  hasNextPage: PropTypes.bool,
+  hasPrevPage: PropTypes.bool,
   hidePageIndices: PropTypes.bool,
   isLoaded: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
@@ -97,6 +99,8 @@ const AuthoritiesSearch = ({
   pageSize,
   onSubmitSearch,
   hidePageIndices,
+  hasNextPage,
+  hasPrevPage,
 }) => {
   const intl = useIntl();
   const [, getNamespace] = useNamespace();
@@ -416,6 +420,8 @@ const AuthoritiesSearch = ({
       >
         <SearchResultsList
           authorities={authorities}
+          hasNextPage={hasNextPage}
+          hasPrevPage={hasPrevPage}
           totalResults={totalRecords}
           pageSize={pageSize}
           onNeedMoreData={handleLoadMore}
@@ -445,6 +451,8 @@ AuthoritiesSearch.propTypes = propTypes;
 AuthoritiesSearch.defaultProps = {
   hidePageIndices: false,
   query: '',
+  hasNextPage: null,
+  hasPrevPage: null,
 };
 
 export default AuthoritiesSearch;


### PR DESCRIPTION
## Description
Override default MCL prev and next button disabling

## Screenshots

https://user-images.githubusercontent.com/19309423/169289374-3efee374-49f4-4bbe-8e15-cce053605e0f.mp4

## Related PRs
https://github.com/folio-org/stripes-components/pull/1800

## Issues
[UIMARCAUTH-140](https://issues.folio.org/browse/UIMARCAUTH-140)