### PR TITLE
UIMARCAUTH-144: increased time delay to 1.5s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [UIMARCAUTH-121](https://issues.folio.org/browse/UIMARCAUTH-121) Export .csv file to load to Data export to create the .mrc file of selected authority records
 - [FOLIO-3477](https://issues.folio.org/browse/FOLIO-3477) FE: update outdated dependencies.
 - [UIMARCAUTH-143](https://issues.folio.org/browse/UIMARCAUTH-143) FE: Update Personal name, Corporate/Conference name and Corporate name Search/Browse options
+- [UIMARCAUTH-144](https://issues.folio.org/browse/UIMARCAUTH-144) Deleted "MARC Authority" records display at result list
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
@@ -19,7 +19,7 @@ const useAuthorityDelete = ({ onError, onSuccess, ...restOptions }) => {
     onError,
     onSuccess: async () => {
       // Creating a delay because result list takes some time to update
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 1500));
       queryClient.invalidateQueries(namespace);
       return onSuccess();
     },

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
@@ -37,7 +37,7 @@ describe('useAuthorityDeleteMutation', () => {
     await waitForNextUpdate();
 
     expect(deleteMock).toHaveBeenCalled();
-    act(() => jest.advanceTimersByTime(600));
+    act(() => jest.advanceTimersByTime(1600));
     expect(await successMock).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Purpose
Deleted "MARC Authority" records displayed in result list. 

## Approach
Increased delete request time delay from 0.5s to 1.5s

## Issues
[UIMARCAUTH-144](https://issues.folio.org/browse/UIMARCAUTH-144)