### PR TITLE
UIMARCAUTH-146: Export .csv file failed because of missing permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [FOLIO-3477](https://issues.folio.org/browse/FOLIO-3477) FE: update outdated dependencies.
 - [UIMARCAUTH-143](https://issues.folio.org/browse/UIMARCAUTH-143) FE: Update Personal name, Corporate/Conference name and Corporate name Search/Browse options
 - Pin @vue/compiler-sfc to fix formatjs-compile errors
+- [UIMARCAUTH-146](https://issues.folio.org/browse/UIMARCAUTH-146) Export ".csv" file failed because of missing permission
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
           "search.authorities.collection.get",
           "search.facets.collection.get",
           "source-storage.records.get",
-          "inventory-storage.authorities.item.get"
+          "inventory-storage.authorities.item.get",
+          "data-export.quick.export.post"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
To fix export ".csv" file failed because of missing permission

## Approach
Extended _subPermissions_ of "MARC Authority: View MARC authority record" with "data-export.quick.export.post" permission.

## Issues
[UIMARCAUTH-146](https://issues.folio.org/browse/UIMARCAUTH-146)
