### PR TITLE
UIMARCAUTH-132 Apply to MARC Authority:  Optimistic locking: display error message to inform user about OL

### DIFF
--- a/src/routes/AuthorityQuickMarcEditRoute/AuthorityQuickMarcEditRoute.js
+++ b/src/routes/AuthorityQuickMarcEditRoute/AuthorityQuickMarcEditRoute.js
@@ -27,9 +27,7 @@ const AuthorityQuickMarcEditRoute = () => {
   const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITIES });
   const { setIsGoingToBaseURL } = useContext(AuthoritiesSearchContext);
 
-  const onClose = useCallback(async recordRoute => {
-    const recordId = recordRoute.split('/')[1];
-
+  const onClose = useCallback(async recordId => {
     await new Promise(resolve => setTimeout(resolve, 1000));
 
     queryClient.invalidateQueries(namespace);
@@ -46,6 +44,7 @@ const AuthorityQuickMarcEditRoute = () => {
       type="quick-marc"
       basePath={match.path}
       onClose={onClose}
+      externalRecordPath="/marc-authorities/authorities"
     >
       <FormattedMessage id="ui-inventory.quickMarcNotAvailable" />
     </Pluggable>


### PR DESCRIPTION
## Description
Pass authority record path to quickMARC, which fixes latest version link

## Screenshots

https://user-images.githubusercontent.com/19309423/169529676-e72ddb92-9bb6-494c-aaa9-3fe722586cb3.mp4


## Issues
[UIMARCAUTH-132](https://issues.folio.org/browse/UIMARCAUTH-132)