### PR TITLE
UIMARCAUTH-137: Fix multiple requests when querying for status after delete

### DIFF
--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
@@ -31,7 +31,7 @@ const useAuthorityDelete = ({ onError, onSuccess, ...restOptions }) => {
 
       while (deleteRequestStatus !== 'COMPLETED' && requestCount !== maxRequestAttempts) {
         const statusResponse = await ky.get(MARC_RECORD_STATUS_API, { searchParams: { actionId } });
-        const { status } = statusResponse.json();
+        const { status } = await statusResponse.json();
 
         deleteRequestStatus = status;
         requestCount++;


### PR DESCRIPTION
## Purpose
Await for status to be defined to fix multiple requests when querying for status after deleted MARC Authority record.

Fix for [this PR](https://github.com/folio-org/ui-marc-authorities/pull/151)

## Screenshots
Now we have one preflight request to `/record-editor/records/status?actionId=<id>` and one GET request:

![image](https://user-images.githubusercontent.com/84023879/169861323-8e2603de-6e95-470a-bbf2-9ab4a5905854.png)

## Issues
[UIMARCAUTH-137](https://issues.folio.org/browse/UIMARCAUTH-137)