### PR TITLE
UIMARCAUTH-149: Update NodeJS to v16 in GitHub Actions

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -25,9 +25,9 @@ jobs:
       COMPILE_TRANSLATION_FILES: 'true'
       PUBLISH_MOD_DESCRIPTOR: true
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
-      FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
+      FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '12'
+      NODEJS_VERSION: '16'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 - [UIMARCAUTH-144](https://issues.folio.org/browse/UIMARCAUTH-144) Deleted "MARC Authority" records display at result list
 - [UIMARCAUTH-151](https://issues.folio.org/browse/UIMARCAUTH-151) Change request param headingTypeExt to isTitleHeadingRef
 - [UIMARCAUTH-140](https://issues.folio.org/browse/UIMARCAUTH-140) [Browse] The page without results is displayed when user go to the last page of result list.
-- [UIMARCAUTH-145](https://issues.folio.org/browse/UIMARCAUTH-145) FE: update outdated dependencies
+- [UIMARCAUTH-145](https://issues.folio.org/browse/UIMARCAUTH-145) FE: update outdated dependencies.
+- [UIMARCAUTH-149](https://issues.folio.org/browse/UIMARCAUTH-149) Update NodeJS to v16 in GitHub Actions.
 
 ## [1.0.5](https://github.com/folio-org/ui-marc-authorities/tree/v1.0.5) (2022-04-15)
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/folio-org/ui-marc-authorities",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.20.1"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "stripes serve",


### PR DESCRIPTION
## Purpose
Update NodeJS to v16 in GitHub Actions.

## Issues
[UIMARCAUTH-149](https://issues.folio.org/browse/UIMARCAUTH-149)