### PR TITLE
UIMARCAUTH-163: The row with "Heading/reference" value doesn't highlight at result list after editing matched tags value more than 1 time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-marc-authorities
 
-## In Progress
+## [1.2.0] (IN PROGRESS)
 
 - [UIMARCAUTH-160](https://issues.folio.org/browse/UIMARCAUTH-160) components are incorrectly imported directly from stripes-* packages
+- [UIMARCAUTH-163](https://issues.folio.org/browse/UIMARCAUTH-163) Fix the row with "Heading/reference" value doesn't highlight at result list after editing matched tags value more than 1 time
 
 ## [1.1.0](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.0) (2022-07-08)
 

--- a/src/hooks/useSortColumnManager/useSortColumnManager.js
+++ b/src/hooks/useSortColumnManager/useSortColumnManager.js
@@ -1,16 +1,10 @@
-import {
-  useState,
-  useEffect,
-} from 'react';
-import queryString from 'query-string';
-import { useLocation } from 'react-router-dom';
+import { useState } from 'react';
 
 import { sortOrders } from '../../constants';
 
 const useSortColumnManager = options => {
-  const location = useLocation();
-  const [sortedColumn, setSortedColumn] = useState('');
-  const [sortOrder, setSortOrder] = useState('');
+  const [sortedColumn, setSortedColumn] = useState(options?.initialParams?.sort || '');
+  const [sortOrder, setSortOrder] = useState(options?.initialParams?.order || '');
 
   const onHeaderClick = (_, metadata) => {
     const { name } = metadata;
@@ -43,23 +37,6 @@ const useSortColumnManager = options => {
     setSortedColumn(option);
     setSortOrder(currentOrder);
   };
-
-  useEffect(() => {
-    const locationSearchParams = queryString.parse(location.search);
-
-    if (Object.keys(locationSearchParams).length <= 0) {
-      return;
-    }
-
-    if (locationSearchParams.sort) {
-      if (locationSearchParams.sort[0] === '-') {
-        onChangeSortOption(locationSearchParams.sort.substring(1), sortOrders.DES);
-      } else {
-        onChangeSortOption(locationSearchParams.sort, sortOrders.ASC);
-      }
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return {
     onChangeSortOption,

--- a/src/hooks/useSortColumnManager/useSortColumnManager.test.js
+++ b/src/hooks/useSortColumnManager/useSortColumnManager.test.js
@@ -135,4 +135,18 @@ describe('Given useSortColumnManager', () => {
       expect(result.current.sortedColumn).toBe(searchResultListColumns.AUTH_REF_TYPE);
     });
   });
+
+  describe('when passing initial sort parameters', () => {
+    it('should return correct sortOrder and selected sortedColumn', () => {
+      const { result } = renderHook(() => useSortColumnManager({
+        initialParams: {
+          sort: searchResultListColumns.HEADING_REF,
+          order: sortOrders.DES,
+        },
+      }));
+
+      expect(result.current.sortOrder).toBe(sortOrders.DES);
+      expect(result.current.sortedColumn).toBe(searchResultListColumns.HEADING_REF);
+    });
+  });
 });

--- a/src/routes/SearchRoute/SearchRoute.js
+++ b/src/routes/SearchRoute/SearchRoute.js
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import queryString from 'query-string';
 
 import { AuthoritiesSearch } from '../../views';
 import {
@@ -11,6 +13,7 @@ import { useSortColumnManager } from '../../hooks';
 import {
   searchableIndexesValues,
   searchResultListColumns,
+  sortOrders,
 } from '../../constants';
 
 const propTypes = {
@@ -22,7 +25,27 @@ const propTypes = {
 
 const PAGE_SIZE = 100;
 
+const getInitialSortParams = searchParams => {
+  const initialOrder = searchParams.sort?.[0] === '-' ? sortOrders.DES : sortOrders.ASC;
+
+  let initialSort;
+
+  if (!searchParams.sort) {
+    initialSort = '';
+  } else if (initialOrder === sortOrders.DES) {
+    initialSort = searchParams.sort.substring(1);
+  } else {
+    initialSort = searchParams.sort;
+  }
+
+  return {
+    sort: initialSort,
+    order: initialOrder,
+  };
+};
+
 const SearchRoute = ({ children }) => {
+  const location = useLocation();
   const {
     searchQuery,
     searchIndex,
@@ -37,6 +60,7 @@ const SearchRoute = ({ children }) => {
   } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
+  const searchParams = queryString.parse(location.search);
   const sortableColumns = [
     searchResultListColumns.AUTH_REF_TYPE,
     searchResultListColumns.HEADING_REF,
@@ -47,7 +71,10 @@ const SearchRoute = ({ children }) => {
     sortedColumn,
     onChangeSortOption,
     onHeaderClick,
-  } = useSortColumnManager({ sortableColumns });
+  } = useSortColumnManager({
+    sortableColumns,
+    initialParams: getInitialSortParams(searchParams),
+  });
 
   const isAdvancedSearch = searchIndex === searchableIndexesValues.ADVANCED_SEARCH;
 


### PR DESCRIPTION
## Description
Added correct initial sort parameters values inside `useSortColumnManager`

## Screenshots

https://user-images.githubusercontent.com/19309423/181725955-addcff54-9a11-41a6-a41d-bce387759ee0.mp4

## Issues
[UIMARCAUTH-163](https://issues.folio.org/browse/UIMARCAUTH-163)
