### PR TITLE
UIMARCAUTH-162 Browse authority | Remove checkbox 'Exclude see from also' from 'Reference' accordion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UIMARCAUTH-160](https://issues.folio.org/browse/UIMARCAUTH-160) components are incorrectly imported directly from stripes-* packages
 - [UIMARCAUTH-163](https://issues.folio.org/browse/UIMARCAUTH-163) Fix the row with "Heading/reference" value doesn't highlight at result list after editing matched tags value more than 1 time
+- [UIMARCAUTH-162](https://issues.folio.org/browse/UIMARCAUTH-162) Browse authority | Remove checkbox "Exclude see from also" from "Reference" accordion.
 
 ## [1.1.0](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.0) (2022-07-08)
 

--- a/src/components/Filters/BrowseFilters/BrowseFilters.js
+++ b/src/components/Filters/BrowseFilters/BrowseFilters.js
@@ -26,6 +26,7 @@ const BrowseFilters = ({ cqlQuery }) => {
   const {
     filters,
     setFilters,
+    navigationSegmentValue,
   } = useContext(AuthoritiesSearchContext);
 
   const [filterAccordions, { handleSectionToggle }] = useSectionToggle({
@@ -54,6 +55,7 @@ const BrowseFilters = ({ cqlQuery }) => {
         id={FILTERS.REFERENCES}
         onChange={applyFilters}
         name={FILTERS.REFERENCES}
+        navigationSegment={navigationSegmentValue}
       />
       <MultiSelectionFacet
         id={FILTERS.HEADING_TYPE}

--- a/src/components/Filters/ReferencesFilter/ReferencesFilter.js
+++ b/src/components/Filters/ReferencesFilter/ReferencesFilter.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import { AcqCheckboxFilter } from '@folio/stripes-acq-components';
 
-import { REFERENCES_OPTIONS } from '../../../constants';
+import { REFERENCES_OPTIONS_BY_SEGMENT } from '../../../constants';
 
 const propTypes = {
   activeFilters: PropTypes.arrayOf(PropTypes.string),
@@ -10,6 +10,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  navigationSegment: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 
@@ -20,6 +21,7 @@ const ReferencesFilter = ({
   id,
   onChange,
   name,
+  navigationSegment,
 }) => (
   <AcqCheckboxFilter
     activeFilters={activeFilters}
@@ -29,7 +31,7 @@ const ReferencesFilter = ({
     labelId="ui-marc-authorities.search.references"
     name={name}
     onChange={onChange}
-    options={REFERENCES_OPTIONS}
+    options={REFERENCES_OPTIONS_BY_SEGMENT[navigationSegment]}
   />
 );
 

--- a/src/components/Filters/ReferencesFilter/ReferencesFilter.test.js
+++ b/src/components/Filters/ReferencesFilter/ReferencesFilter.test.js
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react';
 
 import { ReferencesFilter } from './ReferencesFilter';
+import { navigationSegments } from '../../../constants';
 
 const defaultProps = {
   activeFilters: [],
@@ -13,6 +14,7 @@ const defaultProps = {
   onChange: jest.fn(),
   name: 'references-filter',
   id: 'references-filter',
+  navigationSegment: navigationSegments.search,
 };
 
 const renderReferencesFilter = (props = {}) => render(
@@ -24,7 +26,7 @@ const renderReferencesFilter = (props = {}) => render(
 
 describe('ReferencesFilter', () => {
   beforeEach(() => {
-    defaultProps.onChange.mockClear();
+    jest.clearAllMocks();
   });
 
   it('should render filter with specified options', () => {
@@ -42,5 +44,15 @@ describe('ReferencesFilter', () => {
     act(() => user.click(excludeSeeFromOption));
 
     expect(defaultProps.onChange).toHaveBeenCalled();
+  });
+
+  describe('when navigation segment is Browse', () => {
+    it('should not show exclude see from also option', () => {
+      renderReferencesFilter({
+        navigationSegment: navigationSegments.browse,
+      });
+
+      expect(screen.queryByText('ui-marc-authorities.search.excludeSeeFromAlso')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Filters/SearchFilters/SearchFilters.js
+++ b/src/components/Filters/SearchFilters/SearchFilters.js
@@ -37,6 +37,7 @@ const SearchFilters = ({
   const {
     filters,
     setFilters,
+    navigationSegmentValue,
   } = useContext(AuthoritiesSearchContext);
 
   const [filterAccordions, { handleSectionToggle }] = useSectionToggle({
@@ -79,6 +80,7 @@ const SearchFilters = ({
         id={FILTERS.REFERENCES}
         onChange={applyFilters}
         name={FILTERS.REFERENCES}
+        navigationSegment={navigationSegmentValue}
       />
       <MultiSelectionFacet
         id={FILTERS.SUBJECT_HEADINGS}

--- a/src/constants/references.js
+++ b/src/constants/references.js
@@ -1,15 +1,25 @@
+import { navigationSegments } from './navigationSegments';
+
 export const REFERENCES_VALUES_MAP = {
   excludeSeeFrom: 'excludeSeeFrom',
   excludeSeeFromAlso: 'excludeSeeFromAlso',
 };
 
-export const REFERENCES_OPTIONS = [
-  {
-    labelId: `ui-marc-authorities.search.${REFERENCES_VALUES_MAP.excludeSeeFrom}`,
-    value: REFERENCES_VALUES_MAP.excludeSeeFrom,
-  },
-  {
-    labelId: `ui-marc-authorities.search.${REFERENCES_VALUES_MAP.excludeSeeFromAlso}`,
-    value: REFERENCES_VALUES_MAP.excludeSeeFromAlso,
-  },
-];
+export const REFERENCES_OPTIONS_BY_SEGMENT = {
+  [navigationSegments.search]: [
+    {
+      labelId: `ui-marc-authorities.search.${REFERENCES_VALUES_MAP.excludeSeeFrom}`,
+      value: REFERENCES_VALUES_MAP.excludeSeeFrom,
+    },
+    {
+      labelId: `ui-marc-authorities.search.${REFERENCES_VALUES_MAP.excludeSeeFromAlso}`,
+      value: REFERENCES_VALUES_MAP.excludeSeeFromAlso,
+    },
+  ],
+  [navigationSegments.browse]: [
+    {
+      labelId: `ui-marc-authorities.search.${REFERENCES_VALUES_MAP.excludeSeeFrom}`,
+      value: REFERENCES_VALUES_MAP.excludeSeeFrom,
+    },
+  ],
+};


### PR DESCRIPTION
## Description
Remove `Exclude see from also` option from `References` filter in Browse mode

## Screenshots

https://user-images.githubusercontent.com/19309423/182143180-0faf7742-bfc2-449f-b432-0391133fffed.mp4


## Issues
[UIMARCAUTH-162](https://issues.folio.org/browse/UIMARCAUTH-162)
