### PR TITLE
UIMARCAUTH-172: Delete confirmation modal: Delete button does not dis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UIMARCAUTH-167](https://issues.folio.org/browse/UIMARCAUTH-167) Scroll bars display at the second pane when they don't need
 - [UIMARCAUTH-170](https://issues.folio.org/browse/UIMARCAUTH-170) Tweak the search and view authority components
 - [UIMARCAUTH-169](https://issues.folio.org/browse/UIMARCAUTH-169) The counters at Browse authority pane and "Type of heading" facet options don't match
+- [UIMARCAUTH-172](https://issues.folio.org/browse/UIMARCAUTH-172) Delete confirmation modal: Delete button does not display label
 
 ## [1.1.1](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.1) (2022-08-04)
 

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -232,7 +232,7 @@ const AuthorityView = ({
         buttonStyle="danger"
         onCancel={() => setDeleteModalOpen(false)}
         confirmLabel={
-          <FormattedMessage id="stripes-smart-components.delete.buttonLabel" />
+          <FormattedMessage id="ui-marc-authorities.delete.buttonLabel" />
         }
       />
     </KeyShortCutsWrapper>


### PR DESCRIPTION
## Purpose
Delete confirmation modal: Delete button does not display label

## Approach
The delete button's text id is changed to relate `ui-marc-authorities` module

## Screenshots
![delete-button-text](https://user-images.githubusercontent.com/111242500/188959448-67ca6f7b-a87d-468f-be7e-d435aafd93d1.jpg)


## Issues
[UIMARCAUTH-172](https://issues.folio.org/browse/UIMARCAUTH-172)