### PR TITLE
UIMARCAUTH-183 Results List : Click Link icon/button to select a MARC authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UIMARCAUTH-170](https://issues.folio.org/browse/UIMARCAUTH-170) Tweak the search and view authority components
 - [UIMARCAUTH-169](https://issues.folio.org/browse/UIMARCAUTH-169) The counters at Browse authority pane and "Type of heading" facet options don't match
 - [UIMARCAUTH-182](https://issues.folio.org/browse/UIMARCAUTH-182) Add the Expand the Search & filter pane option
+- [UIMARCAUTH-183](https://issues.folio.org/browse/UIMARCAUTH-183) Results List : Click Link icon/button to select a MARC authority record
 
 ## [1.1.1](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.1) (2022-08-04)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -178,6 +178,7 @@ const AuthoritiesSearch = ({
       <Checkbox
         onChange={() => toggleSelectAll()}
         name="select all authorities"
+        data-testid="select-all-rows-toggle-button"
         checked={selectAll}
         title={selectAll
           ? intl.formatMessage({ id: 'stripes-authority-components.search-results-list.selectAll' })
@@ -329,6 +330,7 @@ const AuthoritiesSearch = ({
       >
         <Checkbox
           checked={Boolean(selectedRows[id])}
+          data-testid="row-toggle-button"
           aria-label={intl.formatMessage({ id: 'ui-marc-authorities.authorities.rows.select' })}
           onChange={() => toggleRowSelection({
             id,
@@ -500,15 +502,11 @@ const AuthoritiesSearch = ({
           loading={isLoading}
           loaded={isLoaded}
           visibleColumns={visibleColumns}
-          selectedRows={selectedRows}
           sortedColumn={sortedColumn}
           sortOrder={sortOrder}
           onHeaderClick={onHeaderClick}
           isFilterPaneVisible={isFilterPaneVisible}
           toggleFilterPane={toggleFilterPane}
-          toggleRowSelection={toggleRowSelection}
-          toggleSelectAll={toggleSelectAll}
-          selectAll={selectAll}
           hasFilters={!!filters.length}
           query={searchQuery}
           hidePageIndices={hidePageIndices}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -27,6 +27,7 @@ import {
   MenuSection,
   Select,
   TextLink,
+  Checkbox,
 } from '@folio/stripes/components';
 import {
   PersistedPaneset,
@@ -119,22 +120,80 @@ const AuthoritiesSearch = ({
   } = useContext(AuthoritiesSearchContext);
   const callout = useContext(CalloutContext);
   const [, setSelectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
+  const [selectedRows, setSelectedRows] = useState({});
+  const [selectAll, setSelectAll] = useState(false);
+  const uniqueAuthorities = useMemo(() => authorities.filter(item => !!item.id), [authorities]);
+  const reportGenerator = useReportGenerator('QuickAuthorityExport');
+  const filterPaneVisibilityKey = getNamespace({ key: 'marcAuthoritiesFilterPaneVisibility' });
+  const [storedFilterPaneVisibility] = useLocalStorage(filterPaneVisibilityKey, true);
+  const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(storedFilterPaneVisibility);
+
+  const uniqueAuthoritiesCount = useMemo(() => {
+    // determine count of unique ids in authorities array.
+    // this is needed to check or uncheck "Select all" checkbox in header when all rows are explicitly
+    // checked or unchecked.
+    const filteredAuthorities = authorities.map(authority => authority.id).filter(id => !!id);
+
+    return new Set(filteredAuthorities).size;
+  }, [authorities]);
+
+  const selectedRowsIds = useMemo(() => (Object.keys(selectedRows)), [selectedRows]);
+  const selectedRowsCount = useMemo(() => (Object.keys(selectedRows).length), [selectedRows]);
+
+  const rowExistsInSelectedRows = row => {
+    return selectedRowsIds.includes(row.id);
+  };
 
   const recordToHighlight = useHighlightEditedRecord(authorities);
 
+  const getSelectAllRowsState = () => {
+    const newSelectedRows = { ...selectedRows };
+
+    if (!selectAll) {
+      // check each of the authorities, if it is not present in selectedRows, add to it
+      uniqueAuthorities.forEach(item => {
+        if (!selectedRowsIds.includes(item.id)) {
+          newSelectedRows[item.id] = item;
+        }
+      });
+    } else {
+      // check each of the authorities, if it is present in selectedRows, remove it
+      uniqueAuthorities.forEach(item => {
+        if (selectedRowsIds.includes(item.id)) {
+          delete newSelectedRows[item.id];
+        }
+      });
+    }
+
+    return newSelectedRows;
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedRows(getSelectAllRowsState());
+    setSelectAll(prev => !prev);
+  };
+
   const columnMapping = {
-    [searchResultListColumns.SELECT]: null,
+    [searchResultListColumns.SELECT]: (
+      <Checkbox
+        onChange={() => toggleSelectAll()}
+        name="select all authorities"
+        checked={selectAll}
+        title={selectAll
+          ? intl.formatMessage({ id: 'stripes-authority-components.search-results-list.selectAll' })
+          : intl.formatMessage({ id: 'stripes-authority-components.search-results-list.unselectAll' })
+        }
+      />
+    ),
     [searchResultListColumns.AUTH_REF_TYPE]: <FormattedMessage id="stripes-authority-components.search-results-list.authRefType" />,
     [searchResultListColumns.HEADING_REF]: <FormattedMessage id="stripes-authority-components.search-results-list.headingRef" />,
     [searchResultListColumns.HEADING_TYPE]: <FormattedMessage id="stripes-authority-components.search-results-list.headingType" />,
   };
+
   const {
     visibleColumns,
     toggleColumn,
   } = useColumnManager(prefix, columnMapping);
-
-  const reportGenerator = useReportGenerator('QuickAuthorityExport');
-  const filterPaneVisibilityKey = getNamespace({ key: 'marcAuthoritiesFilterPaneVisibility' });
 
   useEffect(() => {
     const selectedIndex = searchIndex !== searchableIndexesValues.KEYWORD ? searchIndex : '';
@@ -187,29 +246,6 @@ const AuthoritiesSearch = ({
     sortOrder,
     sortedColumn,
   ]);
-
-  const [storedFilterPaneVisibility] = useLocalStorage(filterPaneVisibilityKey, true);
-  const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(storedFilterPaneVisibility);
-  const [selectedRows, setSelectedRows] = useState({});
-  const [selectAll, setSelectAll] = useState(false);
-
-  const selectedRowsIds = useMemo(() => (Object.keys(selectedRows)), [selectedRows]);
-  const selectedRowsCount = useMemo(() => (Object.keys(selectedRows).length), [selectedRows]);
-
-  const uniqueAuthorities = useMemo(() => authorities.filter(item => !!item.id), [authorities]);
-
-  const uniqueAuthoritiesCount = useMemo(() => {
-    // determine count of unique ids in authorities array.
-    // this is needed to check or uncheck "Select all" checkbox in header when all rows are explicitly
-    // checked or unchecked.
-    const filteredAuthorities = authorities.map(authority => authority.id).filter(id => !!id);
-
-    return new Set(filteredAuthorities).size;
-  }, [authorities]);
-
-  const rowExistsInSelectedRows = row => {
-    return selectedRowsIds.includes(row.id);
-  };
 
   useEffect(() => {
     // on pagination, when authorities search list change, update "selectAll" checkbox based on the selected rows in the searchList.
@@ -278,36 +314,29 @@ const AuthoritiesSearch = ({
     }
   };
 
-  const getSelectAllRowsState = () => {
-    const newSelectedRows = { ...selectedRows };
-
-    if (!selectAll) {
-      // check each of the authorities, if it is not present in selectedRows, add to it
-      uniqueAuthorities.forEach(item => {
-        if (!selectedRowsIds.includes(item.id)) {
-          newSelectedRows[item.id] = item;
-        }
-      });
-    } else {
-      // check each of the authorities, if it is present in selectedRows, remove it
-      uniqueAuthorities.forEach(item => {
-        if (selectedRowsIds.includes(item.id)) {
-          delete newSelectedRows[item.id];
-        }
-      });
-    }
-
-    return newSelectedRows;
-  };
-
-  const toggleSelectAll = () => {
-    setSelectedRows(getSelectAllRowsState());
-    setSelectAll(prev => !prev);
-  };
-
   const toggleFilterPane = () => {
     setIsFilterPaneVisible(!isFilterPaneVisible);
     writeStorage(filterPaneVisibilityKey, !isFilterPaneVisible);
+  };
+
+  const formatter = {
+    // eslint-disable-next-line react/prop-types
+    select: ({ id, ...rowData }) => id && (
+      <div // eslint-disable-line jsx-a11y/click-events-have-key-events
+        tabIndex="0"
+        role="button"
+        onClick={e => e.stopPropagation()}
+      >
+        <Checkbox
+          checked={Boolean(selectedRows[id])}
+          aria-label={intl.formatMessage({ id: 'ui-marc-authorities.authorities.rows.select' })}
+          onChange={() => toggleRowSelection({
+            id,
+            ...rowData,
+          })}
+        />
+      </div>
+    ),
   };
 
   const options = Object.values(sortableSearchResultListColumns).map(option => ({
@@ -461,6 +490,8 @@ const AuthoritiesSearch = ({
       >
         <SearchResultsList
           authorities={authorities}
+          columnMapping={columnMapping}
+          formatter={formatter}
           hasNextPage={hasNextPage}
           hasPrevPage={hasPrevPage}
           totalResults={totalRecords}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -3,7 +3,6 @@ import {
   render,
   fireEvent,
 } from '@testing-library/react';
-import mockMapValues from 'lodash/mapValues';
 
 import { runAxeTest } from '@folio/stripes-testing';
 
@@ -37,24 +36,6 @@ jest.mock('react-router', () => ({
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useAuthorities: () => ({ authorities: [] }),
-  SearchResultsList: props => {
-    const mapedProps = mockMapValues(props, prop => ((typeof prop === 'object') ? JSON.stringify(prop) : prop));
-
-    return (
-      <div data-testid="SearchResultsList" {...mapedProps}>
-        <button type="button" data-testid="select-all-rows-toggle-button" onClick={() => props.toggleSelectAll()}>select-all-rows-toggle-button</button>
-        {props.authorities.map(authority => (
-          <button
-            type="button"
-            data-testid="row-toggle-button"
-            onClick={() => props.toggleRowSelection({ ...authority })}
-          >
-            row-toggle-button
-          </button>
-        ))}
-      </div>
-    );
-  },
   AuthoritiesSearchPane: props => (
     <div>
       AuthoritiesSearchPane
@@ -130,22 +111,10 @@ describe('Given AuthoritiesSearch', () => {
     expect(getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' })).toBeDefined();
   });
 
-  it('should be default sort order', () => {
-    const { getByTestId } = renderAuthoritiesSearch();
-
-    expect(getByTestId('SearchResultsList')).toHaveAttribute('sortOrder', 'ascending');
-  });
-
-  it('should not be sorted by any column', () => {
-    const { getByTestId } = renderAuthoritiesSearch();
-
-    expect(getByTestId('SearchResultsList')).toHaveAttribute('sortedColumn', 'headingRef');
-  });
-
   it('should not display count of selected rows on panesub untill no rows are selected', () => {
     const { queryByText } = renderAuthoritiesSearch();
 
-    expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeNull();
+    expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeNull();
   });
 
   describe('when click on row checkbox', () => {
@@ -156,7 +125,7 @@ describe('Given AuthoritiesSearch', () => {
 
       fireEvent.click(rowToggleButtons[0]);
 
-      expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeDefined();
+      expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeDefined();
     });
   });
 
@@ -169,7 +138,7 @@ describe('Given AuthoritiesSearch', () => {
       fireEvent.click(rowToggleButtons[0]);
       fireEvent.click(rowToggleButtons[0]);
 
-      expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeNull();
+      expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeNull();
     });
   });
 
@@ -279,7 +248,7 @@ describe('Given AuthoritiesSearch', () => {
           fireEvent.click(getByRole('button', { name: 'ui-marc-authorities.export-selected-records' }));
 
           expect(queryByText('ui-marc-authorities.export.success')).toBeDefined();
-          await waitFor(() => expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeNull);
+          await waitFor(() => expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeNull);
         });
 
         it('should be able to show error toast message', () => {
@@ -336,17 +305,13 @@ describe('Given AuthoritiesSearch', () => {
       it('should hide "Type of Heading" column', () => {
         const {
           getByRole,
-          getByTestId,
-        } = renderAuthoritiesSearch();
+          queryByRole,
+        } = renderAuthoritiesSearch({ authorities });
 
         fireEvent.click(getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' }));
         fireEvent.click(getByRole('checkbox', { name: 'stripes-authority-components.search-results-list.headingType' }));
 
-        expect(getByTestId('SearchResultsList')).toHaveAttribute('visibleColumns', JSON.stringify([
-          searchResultListColumns.SELECT,
-          searchResultListColumns.AUTH_REF_TYPE,
-          searchResultListColumns.HEADING_REF,
-        ]));
+        expect(queryByRole('button', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeNull();
       });
     });
   });
@@ -359,7 +324,7 @@ describe('Given AuthoritiesSearch', () => {
 
       fireEvent.click(selectAllRowsToggleButton);
 
-      expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeDefined();
+      expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeDefined();
     });
   });
 
@@ -372,7 +337,7 @@ describe('Given AuthoritiesSearch', () => {
       fireEvent.click(selectAllRowsToggleButton);
       fireEvent.click(selectAllRowsToggleButton);
 
-      expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeNull();
+      expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeNull();
     });
   });
 
@@ -384,7 +349,7 @@ describe('Given AuthoritiesSearch', () => {
 
       fireEvent.click(resetAllButton);
 
-      expect(queryByText('ui-inventory.instances.rows.recordsSelected')).toBeNull();
+      expect(queryByText('ui-marc-authorities.authorities.rows.recordsSelected')).toBeNull();
     });
   });
 

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -6,3 +6,4 @@ import './stripesCore.mock';
 import './stripesIcon.mock';
 import './stripesSmartComponent.mock';
 import './matchMedia.mock';
+import './reactVirtializedAutoSizer.mock';

--- a/test/jest/__mock__/reactVirtializedAutoSizer.mock.js
+++ b/test/jest/__mock__/reactVirtializedAutoSizer.mock.js
@@ -1,0 +1,4 @@
+jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({
+  height: 1000,
+  width: 1000,
+}));

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -10,6 +10,7 @@
   "actions.menuSection.sortBy.relevance": "Relevance",
 
   "authorities.rows.recordsSelected": "{count, number} {count, plural, one {record} other {records}} selected",
+  "authorities.rows.select": "Select Authority record",
 
   "authority-record.edit": "Edit",
   "authority-record.delete": "Delete",


### PR DESCRIPTION
## Description
Move row selection functionality from `stripes-authority-components` 

## Screenshots

https://user-images.githubusercontent.com/19309423/189884191-2cc8ca5d-1f89-49ea-a6a4-4ec7e28a896d.mp4


## Issues
[UIMARCAUTH-183](https://issues.folio.org/browse/UIMARCAUTH-183)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/24
https://github.com/folio-org/ui-plugin-find-authority/pull/28