### PR TITLE
UIMARCAUTH-186 Browse | The counter of selected records for export doesn't display at pane header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UIMARCAUTH-170](https://issues.folio.org/browse/UIMARCAUTH-170) Tweak the search and view authority components
 - [UIMARCAUTH-182](https://issues.folio.org/browse/UIMARCAUTH-182) Add the Expand the Search & filter pane option
 - [UIMARCAUTH-183](https://issues.folio.org/browse/UIMARCAUTH-183) Results List : Click Link icon/button to select a MARC authority record
+- [UIMARCAUTH-186](https://issues.folio.org/browse/UIMARCAUTH-186) Browse | The counter of selected records for export doesn't display at pane header
 
 ## [1.1.2](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.2) (2022-09-14)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -430,13 +430,9 @@ const AuthoritiesSearch = ({
     );
   };
 
-  const renderPaneSub = () => {
-    if (navigationSegmentValue === navigationSegments.browse) {
-      return null;
-    }
-
-    return (
-      <span className={css.delimiter}>
+  const renderPaneSub = () => (
+    <span className={css.delimiter}>
+      {navigationSegmentValue !== navigationSegments.browse && (
         <span>
           {intl.formatMessage({
             id: 'stripes-authority-components.search-results-list.paneSub',
@@ -444,18 +440,18 @@ const AuthoritiesSearch = ({
             totalRecords,
           })}
         </span>
-        {
-          !!selectedRowsCount &&
-          <span>
-            <FormattedMessage
-              id="ui-marc-authorities.authorities.rows.recordsSelected"
-              values={{ count: selectedRowsCount }}
-            />
-          </span>
-        }
-      </span>
-    );
-  };
+      )}
+      {
+        !!selectedRowsCount &&
+        <span>
+          <FormattedMessage
+            id="ui-marc-authorities.authorities.rows.recordsSelected"
+            values={{ count: selectedRowsCount }}
+          />
+        </span>
+      }
+    </span>
+  );
 
   const renderResultsFirstMenu = () => {
     if (isFilterPaneVisible) {


### PR DESCRIPTION
## Description
Display selected records counter in pane header

## Screenshots

https://user-images.githubusercontent.com/19309423/192479653-c03d343c-2196-40a6-be9e-f42b36bbcb91.mp4


## Issues
[UIMARCAUTH-186](https://issues.folio.org/browse/UIMARCAUTH-186)