### PR TITLE
UIMARCAUTH-191 MARC authority app: Authority source/Thesaurus Facet option does not display value when zero results are returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-186](https://issues.folio.org/browse/UIMARCAUTH-186) Browse | The counter of selected records for export doesn't display at pane header
 - [UIMARCAUTH-187](https://issues.folio.org/browse/UIMARCAUTH-187) FE: MARC authority: Create an Authority source facet
 - [UIMARCAUTH-188](https://issues.folio.org/browse/UIMARCAUTH-188) MARC Authorities app: Add a11y tests
+- [UIMARCAUTH-188](https://issues.folio.org/browse/UIMARCAUTH-191) MARC authority app: Authority source/Thesaurus Facet option does not display value when zero results are returned
 
 ## [1.1.2](https://github.com/folio-org/ui-marc-authorities/tree/v1.1.2) (2022-09-14)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -19,6 +19,7 @@ import {
   writeStorage,
 } from '@rehooks/local-storage';
 import queryString from 'query-string';
+import pick from 'lodash/pick';
 
 import {
   Button,
@@ -205,7 +206,7 @@ const AuthoritiesSearch = ({
     const selectedIndex = searchIndex !== searchableIndexesValues.KEYWORD ? searchIndex : '';
 
     const queryParams = {
-      ...queryString.parse(location.search),
+      ...pick(queryString.parse(location.search), ['authRefType', 'headingRef']),
       query: searchQuery,
       qindex: selectedIndex,
       ...filters,


### PR DESCRIPTION
## Description
Remove filters from url when clicking "Reset all"

## Screenshots

https://user-images.githubusercontent.com/19309423/196977840-60537202-ade2-4ccc-bcca-af1bb54b1cb3.mp4

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/35

## Issues
[UIMARCAUTH-191](https://issues.folio.org/browse/UIMARCAUTH-191)