### PR TITLE
UIMARCAUTH-199 Loading Pane snapping out of resize cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UIMARCAUTH-177](https://issues.folio.org/browse/UIMARCAUTH-177) MARC authority: Search Results/Browse List: Add a new column Number of titles
 - [UIMARCAUTH-178](https://issues.folio.org/browse/UIMARCAUTH-178) MARC authority: Delete MARC authority record handling
+- [UIMARCAUTH-199](https://issues.folio.org/browse/UIMARCAUTH-199) Loading Pane snapping out of resize cache.
 
 ## [2.0.0](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.0) (2022-10-26)
 

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -113,7 +113,7 @@ const AuthorityView = ({
   });
 
   if (marcSource.isLoading || authority.isLoading) {
-    return <LoadingPane />;
+    return <LoadingPane id="marc-view-pane" />;
   }
 
   if (!authority.data) {


### PR DESCRIPTION
## Description
Loading Pane snapping out of resize cache.

Change `id` of loading pane to be the same as marc view pane for width caching to apply

## Screenshots

https://user-images.githubusercontent.com/19309423/203037971-7aac4a94-851c-4e9a-9a53-b4b876e46b6e.mp4



## Issues
[UIMARCAUTH-199](https://issues.folio.org/browse/UIMARCAUTH-199)