### PR TITLE
UIMARCAUTH-203: Error appears when the user executes search in "MARC Authority" app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UIMARCAUTH-177](https://issues.folio.org/browse/UIMARCAUTH-177) MARC authority: Search Results/Browse List: Add a new column Number of titles
 - [UIMARCAUTH-178](https://issues.folio.org/browse/UIMARCAUTH-178) MARC authority: Delete MARC authority record handling
+- [UIMARCAUTH-203](https://issues.folio.org/browse/UIMARCAUTH-203) Error appears when the user executes search in "MARC Authority" app
 
 ## [2.0.0](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.0) (2022-10-26)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -3,6 +3,7 @@ import {
   useEffect,
   useContext,
   useMemo,
+  useCallback,
 } from 'react';
 import {
   useHistory,
@@ -364,7 +365,7 @@ const AuthoritiesSearch = ({
     ...options,
   ];
 
-  const formatAuthorityRecordLink = authority => {
+  const formatAuthorityRecordLink = useCallback(authority => {
     const search = queryString.parse(location.search);
     const newSearch = queryString.stringify({
       ...search,
@@ -373,11 +374,11 @@ const AuthoritiesSearch = ({
     });
 
     return `${match.path}/authorities/${authority.id}?${newSearch}`;
-  };
+  }, [location.search, match.path]);
 
-  const redirectToAuthorityRecord = authority => {
+  const redirectToAuthorityRecord = useCallback(authority => {
     history.push(formatAuthorityRecordLink(authority));
-  };
+  }, [history, formatAuthorityRecordLink]);
 
   useAutoOpenDetailView(authorities, redirectToAuthorityRecord);
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Fix constant re-rendering after doing a search with one result.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIMARCAUTH-203](https://issues.folio.org/browse/UIMARCAUTH-203)

## Related PRs
[UISAUTCOMP-27](https://github.com/folio-org/stripes-authority-components/pull/42)
[UIPFAUTH-37](https://github.com/folio-org/ui-plugin-find-authority/pull/45)

## Screencast






https://user-images.githubusercontent.com/77053927/203137015-7796f562-6dbc-460a-838e-a8269cf91085.mp4







## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
