### PR TITLE
UIMARCAUTH-222: Missing permission for Marc Authority edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UIMARCAUTH-177](https://issues.folio.org/browse/UIMARCAUTH-177) MARC authority: Search Results/Browse List: Add a new column Number of titles
 - [UIMARCAUTH-178](https://issues.folio.org/browse/UIMARCAUTH-178) MARC authority: Delete MARC authority record handling
+- [UIMARCAUTH-222](https://issues.folio.org/browse/UIMARCAUTH-222) MARC Authority: Edit MARC authority record
 
 ## [2.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.1) (2022-11-28)
 

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
         "displayName": "MARC Authority: Edit MARC authority record",
         "subPermissions": [
           "ui-marc-authorities.authority-record.view",
-          "records-editor.records.item.put"
+          "records-editor.records.item.put",
+          "instance-authority-links.authorities.bulk.post"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Description
Missing permission for request "/links/authorities/bulk/count". Added it to "MARC Authority: Edit MARC authority record" permission in ui-matc-authorities/package.json

## Screenshots
Will be posted soon

## Issues
[UIMARCAUTH-222](https://issues.folio.org/browse/UIMARCAUTH-222)