### PR TITLE
Revert "UIMARCAUTH-221 Align the module with API breaking change"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Change history for ui-marc-authorities
 
-## [3.0.0](IN PROGRESS)
+## [2.1.0](IN PROGRESS)
 
 - [UIMARCAUTH-177](https://issues.folio.org/browse/UIMARCAUTH-177) MARC authority: Search Results/Browse List: Add a new column Number of titles
 - [UIMARCAUTH-178](https://issues.folio.org/browse/UIMARCAUTH-178) MARC authority: Delete MARC authority record handling
 - [UIMARCAUTH-222](https://issues.folio.org/browse/UIMARCAUTH-222) MARC Authority: Edit MARC authority record
-- [UIMARCAUTH-221](https://issues.folio.org/browse/UIMARCAUTH-221) Align the module with mod-search API breaking change
 
 ## [2.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.1) (2022-11-28)
 

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
       }
     ],
     "okapiInterfaces": {
-      "search": "1.0",
-      "browse": "1.0",
+      "search": "0.6",
+      "browse": "0.3",
       "source-storage-records": "3.0",
       "records-editor.records": "3.1"
     },


### PR DESCRIPTION
Reverts folio-org/ui-marc-authorities#226  until back-end interface has been updated