### PR TITLE
UIMARCAUTH-220: Remove button 'Blind authority headings (CSV)'

### DIFF
--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -222,11 +222,9 @@ describe('Given AuthoritiesSearch', () => {
       fireEvent.click(getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' }));
 
       const marcAuthorityHeadingsButton = getByRole('button', { name: 'ui-marc-authorities.reports.marcAuthorityHeadings' });
-      const blindAuthorityHeadingsButton = getByRole('button', { name: 'ui-marc-authorities.reports.blindAuthorityHeadings' });
       const failedUpdatesButton = getByRole('button', { name: 'ui-marc-authorities.reports.failedUpdates' });
 
       expect(marcAuthorityHeadingsButton).toBeVisible();
-      expect(blindAuthorityHeadingsButton).toBeVisible();
       expect(failedUpdatesButton).toBeVisible();
     });
 

--- a/src/views/AuthoritiesSearch/Reports/Reports.js
+++ b/src/views/AuthoritiesSearch/Reports/Reports.js
@@ -55,9 +55,6 @@ const Reports = ({
         translationId: 'ui-marc-authorities.reports.marcAuthorityHeadings',
       })}
       {renderReport({
-        translationId: 'ui-marc-authorities.reports.blindAuthorityHeadings',
-      })}
-      {renderReport({
         translationId: 'ui-marc-authorities.reports.failedUpdates',
       })}
     </MenuSection>

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -46,6 +46,5 @@
 
   "reports": "Reports",
   "reports.marcAuthorityHeadings": "MARC authority headings updates (CSV)",
-  "reports.blindAuthorityHeadings": "Blind authority headings (CSV)",
   "reports.failedUpdates": "Failed updates: linked bibliographic fields (CSV)"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Remove button 'Blind authority headings (CSV)'
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIMARCAUTH-220](https://issues.folio.org/browse/UIMARCAUTH-220?focusedCommentId=155456&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-155456)

## Screenshots

![image](https://user-images.githubusercontent.com/77053927/214029577-4c33fbf2-b4b1-4f60-bdb0-43313925fa46.png)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
