### PR TITLE
UIMARCAUTH-234 Fix incorrect payload structure for Authorities updates export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [UIMARCAUTH-221](https://issues.folio.org/browse/UIMARCAUTH-221) Align the module with mod-search API breaking change
 - [UIMARCAUTH-226](https://issues.folio.org/browse/UIMARCAUTH-226) Bump quick-marc to 6.0.0
 - [UIMARCAUTH-208](https://issues.folio.org/browse/UIMARCAUTH-208) Global Heading Report | UX | MARC authority headings updates report
+- [UIMARCAUTH-234](https://issues.folio.org/browse/UIMARCAUTH-234) Fix incorrect payload structure for Authorities updates export.
 
 ## [2.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.1) (2022-11-28)
 

--- a/src/queries/useExportReport/useExportReport.js
+++ b/src/queries/useExportReport/useExportReport.js
@@ -32,7 +32,9 @@ const useExportReport = ({
   const doExport = useCallback((type, data) => {
     mutate({
       type: JOB_TYPE_MAP[type],
-      exportTypeSpecificParameters: data,
+      exportTypeSpecificParameters: {
+        authorityControlExportConfig: data,
+      },
     });
   }, [mutate]);
 


### PR DESCRIPTION
## Description
Fix missing payload attribute for export authority headings updates

## Issues
[UIMARCAUTH-234](https://issues.folio.org/browse/UIMARCAUTH-234)