### PR TITLE
UIMARCAUTH-236 unpin @vue/compiler-sfc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [UIMARCAUTH-208](https://issues.folio.org/browse/UIMARCAUTH-208) Global Heading Report | UX | MARC authority headings updates report
 - [UIMARCAUTH-233](https://issues.folio.org/browse/UIMARCAUTH-233) MARC Authority | Print Source record
 - [UIMARCAUTH-234](https://issues.folio.org/browse/UIMARCAUTH-234) Fix incorrect payload structure for Authorities updates export.
+- [UIMARCAUTH-236](https://issues.folio.org/browse/UIMARCAUTH-236) Unpin `@vue/compiler-sfc` which no longer causes node conflict
 
 ## [2.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.1) (2022-11-28)
 

--- a/package.json
+++ b/package.json
@@ -85,9 +85,6 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },
-  "resolutions": {
-    "@vue/compiler-sfc": "3.2.33"
-  },
   "stripes": {
     "actsAs": [
       "app"


### PR DESCRIPTION
This package no longer causes node version conflicts and so no longer needs to be pinned.

Refs [UIMARCAUTH-236](https://issues.folio.org/browse/UIMARCAUTH-236)
