### PR TITLE
UIMARCAUTH-240  Incorrect "Job type",  "Output type", "Description" for headings updates report export job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [UIMARCAUTH-231](https://issues.folio.org/browse/UIMARCAUTH-231) Remove 'Failed updates reports' option from Orchid release.
 - [UIMARCAUTH-237](https://issues.folio.org/browse/UIMARCAUTH-237) Add instance-authority-links.authority-statistics.collection.get.
 - [UIMARCAUTH-236](https://issues.folio.org/browse/UIMARCAUTH-236) Unpin `@vue/compiler-sfc` which no longer causes node conflict
+- [UIMARCAUTH-240](https://issues.folio.org/browse/UIMARCAUTH-240) Incorrect "Job type",  "Output type", "Description" for headings updates report export job
 
 ## [2.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v2.0.1) (2022-11-28)
 

--- a/src/queries/useExportReport/useExportReport.js
+++ b/src/queries/useExportReport/useExportReport.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useMutation } from 'react-query';
+import { useIntl } from 'react-intl';
 
 import { useOkapiKy } from '@folio/stripes/core';
 
@@ -15,6 +16,7 @@ const useExportReport = ({
   onSuccess,
 }) => {
   const ky = useOkapiKy();
+  const intl = useIntl();
 
   const { mutate } = useMutation({
     mutationFn: json => {
@@ -32,11 +34,13 @@ const useExportReport = ({
   const doExport = useCallback((type, data) => {
     mutate({
       type: JOB_TYPE_MAP[type],
+      description: intl.formatMessage({ id: `ui-marc-authorities.reports.${type}.description` }),
+      outputFormat: intl.formatMessage({ id: `ui-marc-authorities.reports.${type}.outputFormat` }),
       exportTypeSpecificParameters: {
         authorityControlExportConfig: data,
       },
     });
-  }, [mutate]);
+  }, [mutate, intl]);
 
   return {
     doExport,

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -50,6 +50,8 @@
   "reports.failedUpdates": "Failed updates: linked bibliographic fields (CSV)",
   "reports.HEADINGS_UPDATES.success": "<b>Authority headings updates report (Job ID {name})</b> is being generated. Go to the Export manager app to download report. It may take a few minutes for the report to complete.",
   "reports.fail": "We were unable to create this report. Please try again.",
+  "reports.HEADINGS_UPDATES.description": "List of updated MARC authority (1XX) headings",
+  "reports.HEADINGS_UPDATES.outputFormat": "MARC authority headings updates (CSV)",
   
   "reportModal.HEADINGS_UPDATES.label": "Set date range for MARC authority headings updates (CSV) report",
   "reportModal.startDate": "Start date",


### PR DESCRIPTION
## Description
Added `description` and `outputFormat` to authority headings updates reports request


## Screenshots
![image](https://user-images.githubusercontent.com/19309423/220933449-9d65f5d7-4fd5-451e-aff4-b24578d690ff.png)


## Issues
[UIMARCAUTH-240](https://issues.folio.org/browse/UIMARCAUTH-240)