### PR TITLE
UIMARCAUTH-260 Added stripes-authority-components to stripesDeps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change history for ui-marc-authorities
 
-## [3.0.3](IN PROGRESS)
+## [3.1.0](IN PROGRESS)
 
 - [UIMARCAUTH-251](https://issues.folio.org/browse/UIMARCAUTH-251) Browse: Fix Space at the begining and end of query string
 - [UIMARCAUTH-261](https://issues.folio.org/browse/UIMARCAUTH-261) Fix tests.
 - [UIMARCAUTH-239](https://issues.folio.org/browse/UIMARCAUTH-239) Detail Record Actions dropdown menu > Add icons to the left of each action
 - [UIMARCAUTH-253](https://issues.folio.org/browse/UIMARCAUTH-253) Avoid private paths in stripes-core imports.
+- [UIMARCAUTH-260](https://issues.folio.org/browse/UIMARCAUTH-260) Added stripes-authority-components to stripesDeps.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
       "records-editor.records": "3.1"
     },
     "stripesDeps": [
-      "@folio/stripes-acq-components"
+      "@folio/stripes-acq-components",
+      "@folio/stripes-authority-components"
     ],
     "permissionSets": [
       {

--- a/src/views/AuthoritiesSearch/ReportsModal/ReportsModal.test.js
+++ b/src/views/AuthoritiesSearch/ReportsModal/ReportsModal.test.js
@@ -13,11 +13,9 @@ import { REPORT_TYPES } from '../constants';
 const mockOnClose = jest.fn();
 const mockOnSubmit = jest.fn();
 
-const DEFAULT_LOCALE = 'en-US';
-
 const intl = {
   formatMessage: ({ id }) => id,
-  locale: DEFAULT_LOCALE,
+  locale: 'en-US',
 };
 
 jest.mock('react-intl', () => {
@@ -45,7 +43,7 @@ const renderReportsModal = (props = {}) => render(
 describe('Given ReportsModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    intl.locale = DEFAULT_LOCALE;
+    intl.locale = 'en-US';
   });
 
   it('should render with no axe errors', async () => {


### PR DESCRIPTION
## Description
Added `stripes-authority-components` to `stripesDeps` so translations can be included in bundle

## Issues
[UIMARCAUTH-260](https://issues.folio.org/browse/UIMARCAUTH-260)