### PR TITLE
Revert "UIMARCAUTH-272: Upgrade the records-editor.records interface."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-marc-authorities
 
-## [4.0.0](IN PROGRESS)
+## [3.1.0](IN PROGRESS)
 
 - [UIMARCAUTH-251](https://issues.folio.org/browse/UIMARCAUTH-251) Browse: Fix Space at the begining and end of query string
 - [UIMARCAUTH-261](https://issues.folio.org/browse/UIMARCAUTH-261) Fix tests.
@@ -8,7 +8,6 @@
 - [UIMARCAUTH-253](https://issues.folio.org/browse/UIMARCAUTH-253) Avoid private paths in stripes-core imports.
 - [UIMARCAUTH-260](https://issues.folio.org/browse/UIMARCAUTH-260) Added stripes-authority-components to stripesDeps.
 - [UIMARCAUTH-212](https://issues.folio.org/browse/UIMARCAUTH-212) Global Headings Report | UX | Failed updates: linked bibliographic fields (CSV)
-- [UIMARCAUTH-272](https://issues.folio.org/browse/UIMARCAUTH-272) Upgrade the records-editor.records interface.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/marc-authorities",
-  "version": "4.0.0",
+  "version": "3.0.2",
   "description": "MARC Authorities module",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-marc-authorities",
@@ -101,7 +101,7 @@
       "search": "1.0",
       "browse": "1.0",
       "source-storage-records": "3.0",
-      "records-editor.records": "4.0"
+      "records-editor.records": "3.1"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components",


### PR DESCRIPTION
Reverts folio-org/ui-marc-authorities#278