### PR TITLE
UIMARCAUTH-273 Added missing permission for editing MARC Authority records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [UIMARCAUTH-260](https://issues.folio.org/browse/UIMARCAUTH-260) Added stripes-authority-components to stripesDeps.
 - [UIMARCAUTH-212](https://issues.folio.org/browse/UIMARCAUTH-212) Global Headings Report | UX | Failed updates: linked bibliographic fields (CSV)
 - [UIMARCAUTH-272](https://issues.folio.org/browse/UIMARCAUTH-272) Upgrade the records-editor.records interface.
+- [UIMARCAUTH-273](https://issues.folio.org/browse/UIMARCAUTH-273) Added missing permission for editing MARC Authority records.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
           "source-storage.records.get",
           "inventory-storage.authorities.item.get",
           "data-export.quick.export.post",
+          "instance-authority.linking-rules.collection.get",
           "instance-authority-links.authority-statistics.collection.get",
           "instance-authority-links.instance-statistics.collection.get",
           "inventory-storage.authority-source-files.collection.get",


### PR DESCRIPTION
## Description
Added missing permission for editing MARC Authority records.

## Issues
[UIMARCAUTH-273](https://issues.folio.org/browse/UIMARCAUTH-273)