### PR TITLE
UIMARCAUTH-275: Fix the focus of the first result for the Browse search

### DIFF
--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -8,6 +8,7 @@ import {
   AuthoritiesSearchContext,
   SelectedAuthorityRecordContext,
   useAuthoritiesBrowse,
+  useBrowseResultFocus,
 } from '@folio/stripes-authority-components';
 
 import { AuthoritiesSearch } from '../../views';
@@ -52,6 +53,13 @@ const BrowseRoute = ({ children }) => {
     precedingRecordsCount: PRECEDING_RECORDS_COUNT,
   });
 
+  const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);
+
+  const handleNeedMoreData = (...params) => {
+    isPaginationClicked.current = true;
+    handleLoadMore(...params);
+  }
+
   const onSubmitSearch = e => {
     if (e && e.preventDefault) {
       e.preventDefault();
@@ -88,8 +96,9 @@ const BrowseRoute = ({ children }) => {
       isLoaded={isLoaded}
       query={query}
       pageSize={PAGE_SIZE}
+      resultsContainerRef={resultsContainerRef}
       onSubmitSearch={onSubmitSearch}
-      handleLoadMore={handleLoadMore}
+      handleLoadMore={handleNeedMoreData}
       hidePageIndices
     >
       {children}

--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -58,7 +58,7 @@ const BrowseRoute = ({ children }) => {
   const handleNeedMoreData = (...params) => {
     isPaginationClicked.current = true;
     handleLoadMore(...params);
-  }
+  };
 
   const onSubmitSearch = e => {
     if (e && e.preventDefault) {

--- a/src/routes/BrowseRoute/BrowseRoute.test.js
+++ b/src/routes/BrowseRoute/BrowseRoute.test.js
@@ -5,6 +5,11 @@ import { runAxeTest } from '@folio/stripes-testing';
 import BrowseRoute from './BrowseRoute';
 import Harness from '../../../test/jest/helpers/harness';
 
+jest.mock('@folio/stripes-authority-components', () => ({
+  ...jest.requireActual('@folio/stripes-authority-components'),
+  useBrowseResultFocus: jest.fn().mockReturnValue({}),
+}));
+
 jest.mock('../../views', () => ({
   AuthoritiesSearch: ({ children }) => (
     <div>

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -112,6 +112,7 @@ const AuthoritiesSearch = ({
   totalRecords,
   query,
   pageSize,
+  resultsContainerRef,
   onSubmitSearch,
   hidePageIndices,
   hasNextPage,
@@ -603,6 +604,7 @@ const AuthoritiesSearch = ({
           hasPrevPage={hasPrevPage}
           totalResults={totalRecords}
           pageSize={pageSize}
+          resultsContainerRef={resultsContainerRef}
           onNeedMoreData={handleLoadMore}
           loading={isLoading}
           loaded={isLoaded}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -94,6 +94,7 @@ const propTypes = {
   onSubmitSearch: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   query: PropTypes.string,
+  resultsContainerRef: PropTypes.node,
   sortedColumn: PropTypes.string.isRequired,
   sortOrder: PropTypes.oneOf([sortOrders.ASC, sortOrders.DES]).isRequired,
   totalRecords: PropTypes.number.isRequired,
@@ -638,6 +639,7 @@ AuthoritiesSearch.defaultProps = {
   query: '',
   hasNextPage: null,
   hasPrevPage: null,
+  resultsContainerRef: null,
 };
 
 export default AuthoritiesSearch;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
The focus should always be on the first result after clicking the previous/next button.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIMARCAUTH-275](https://issues.folio.org/browse/UIMARCAUTH-275)

## RelastedPRs
[stripes-authority-components/pull/79](https://github.com/folio-org/stripes-authority-components/pull/79)
[ui-plugin-find-authority/pull/63](https://github.com/folio-org/ui-plugin-find-authority/pull/63)

## Screencast


https://user-images.githubusercontent.com/77053927/236485736-321635c5-997d-40d6-85b9-093c083f674c.mp4




## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
