### PR TITLE
UIMARCAUTH-269 "Month" dropdown is Not displayed in date picker element opened in modal window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-212](https://issues.folio.org/browse/UIMARCAUTH-212) Global Headings Report | UX | Failed updates: linked bibliographic fields (CSV)
 - [UIMARCAUTH-272](https://issues.folio.org/browse/UIMARCAUTH-272) Upgrade the records-editor.records interface.
 - [UIMARCAUTH-273](https://issues.folio.org/browse/UIMARCAUTH-273) Added missing permission for editing MARC Authority records.
+- [UIMARCAUTH-269](https://issues.folio.org/browse/UIMARCAUTH-269) "Month" dropdown is Not displayed in date picker element opened in modal window
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/src/views/AuthoritiesSearch/ReportsModal/ReportsModal.js
+++ b/src/views/AuthoritiesSearch/ReportsModal/ReportsModal.js
@@ -55,6 +55,7 @@ const ReportsModal = ({
       data-testid="authorities-report-modal"
       aria-label={intl.formatMessage({ id: `ui-marc-authorities.reportModal.${reportType}.label` })}
       onClose={onClose}
+      enforceFocus={false}
       contentClass={styles.reportsModalContent}
       footer={(
         <ModalFooter>


### PR DESCRIPTION
## Description
Fix for "Month" dropdown is Not displayed in date picker element opened in modal window

## Issue 
[UIMARCAUTH-269](https://issues.folio.org/browse/UIMARCAUTH-269)


