### PR TITLE
UIMARCAUTH-286 Change records-editor.records interface name and version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [UIMARCAUTH-273](https://issues.folio.org/browse/UIMARCAUTH-273) Added missing permission for editing MARC Authority records.
 - [UIMARCAUTH-269](https://issues.folio.org/browse/UIMARCAUTH-269) "Month" dropdown is Not displayed in date picker element opened in modal window
 - [UIMARCAUTH-264](https://issues.folio.org/browse/UIMARCAUTH-264) Retain `Search` and `Browse` search terms.
+- [UIMARCAUTH-286](https://issues.folio.org/browse/UIMARCAUTH-286) Change records-editor.records interface name and permission names to marc-records-editor
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "search": "1.0",
       "browse": "1.0",
       "source-storage-records": "3.0",
-      "records-editor.records": "4.0"
+      "marc-records-editor": "5.0"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components",
@@ -119,7 +119,7 @@
         "subPermissions": [
           "module.marc-authorities.enabled",
           "browse.authorities.collection.get",
-          "records-editor.records.item.get",
+          "marc-records-editor.item.get",
           "search.authorities.collection.get",
           "search.facets.collection.get",
           "source-storage.records.get",
@@ -138,7 +138,7 @@
         "displayName": "MARC Authority: Edit MARC authority record",
         "subPermissions": [
           "ui-marc-authorities.authority-record.view",
-          "records-editor.records.item.put",
+          "marc-records-editor.item.put",
           "instance-authority-links.authorities.bulk.post"
         ],
         "visible": true
@@ -147,7 +147,7 @@
         "permissionName": "ui-marc-authorities.authority-record.delete",
         "displayName": "MARC Authority: Delete MARC authority record",
         "subPermissions": [
-          "records-editor.records.item.delete"
+          "marc-records-editor.item.delete"
         ],
         "visible": true
       }


### PR DESCRIPTION
Change records-editor.records interface name and permission names to marc-records-editor also from 4 to 5 version of interface

## Issue
[UIMARCAUTH-286](https://issues.folio.org/browse/UIMARCAUTH-286)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
