### PR TITLE
UIMARCAUTH-289 New permission: MARC authority: Create MARC authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [UIMARCAUTH-264](https://issues.folio.org/browse/UIMARCAUTH-264) Retain `Search` and `Browse` search terms.
 - [UIMARCAUTH-286](https://issues.folio.org/browse/UIMARCAUTH-286) Change records-editor.records interface name and permission names to marc-records-editor
 - [UIMARCAUTH-288](https://issues.folio.org/browse/UIMARCAUTH-288) Add permission to "MARC Authority: View MARC authority record".
+- [UIMARCAUTH-289](https://issues.folio.org/browse/UIMARCAUTH-289) New permission: MARC authority: Create MARC authority record.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,18 @@
         "visible": true
       },
       {
+        "permissionName": "ui-marc-authorities.authority-record.create",
+        "displayName": "MARC Authority: Create MARC authority record",
+        "subPermissions": [
+          "ui-marc-authorities.authority-record.view",
+          "marc-records-editor.item.post",
+          "instance-authority-links.instances.collection.post",
+          "instance-authority-links.authorities.bulk.post",
+          "marc-records-editor.status.item.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-marc-authorities.authority-record.edit",
         "displayName": "MARC Authority: Edit MARC authority record",
         "subPermissions": [

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -22,6 +22,7 @@
 
   "permission.app.enabled": "UI: MARC Authorities module is enabled",
   "permission.authority-record.view": "MARC Authority: View MARC authority record",
+  "permission.authority-record.create": "MARC Authority: Create MARC authority record",
   "permission.authority-record.edit": "MARC Authority: Edit MARC authority record",
   "permission.authority-record.delete": "MARC Authority: Delete MARC authority record",
 


### PR DESCRIPTION
## Description
New permission: MARC authority: Create MARC authority record

## Issues
[UIMARCAUTH-289](https://issues.folio.org/browse/UIMARCAUTH-289)