### PR TITLE
UIMARCAUTH-298 Add Shared icon to MARC authority search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [UIMARCAUTH-291](https://issues.folio.org/browse/UIMARCAUTH-291) Update markHighlightedFields function with authority Mapping Rules. Added new permission to get mapping-rules.
 - [UIMARCAUTH-300](https://issues.folio.org/browse/UIMARCAUTH-300) *BREAKING* Bump `react` to `v18`.
 - [UIMARCAUTH-268](https://issues.folio.org/browse/UIMARCAUTH-268) Add "Local" or "Shared" to flag MARC authorities.
+- [UIMARCAUTH-298](https://issues.folio.org/browse/UIMARCAUTH-298) Add Shared icon to MARC authority search results.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/mocks/authorities.json
+++ b/mocks/authorities.json
@@ -2,7 +2,8 @@
   "id": "5a404f5d-2c46-4426-9f28-db8d26881b30",
   "headingType": "Personal name",
   "authRefType": "Auth/Ref",
-  "headingRef": "Twain, Mark"
+  "headingRef": "Twain, Mark",
+  "shared": true
 }, {
   "id": "5a404f5d-2c46-4426-9f28-db8d26881b31",
   "headingType": "Personal name",

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.css
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.css
@@ -1,3 +1,5 @@
+@import '@folio/stripes-components/lib/variables';
+
 /**
  * AuthoritiesSearch
  */

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -56,6 +56,7 @@ import {
   SelectedAuthorityRecordContext,
   useAutoOpenDetailView,
   AUTH_REF_TYPES,
+  SharedIcon,
 } from '@folio/stripes-authority-components';
 import { useHighlightEditedRecord } from '@folio/stripes-authority-components/lib/SearchResultsList/useHighlightEditedRecord';
 
@@ -576,14 +577,17 @@ const AuthoritiesSearch = ({
     );
   };
 
-  const renderHeadingRef = (authority, className) => (
-    <TextLink
-      className={className}
-      to={formatAuthorityRecordLink(authority)}
-    >
-      {authority.headingRef}
-    </TextLink>
-  );
+  const renderHeadingRef = (authority, className) => {
+    return (
+      <TextLink
+        className={className}
+        to={formatAuthorityRecordLink(authority)}
+      >
+        {authority.shared && <SharedIcon authority={authority} />}
+        {authority.headingRef}
+      </TextLink>
+    );
+  };
 
   return (
     <PersistedPaneset

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -469,4 +469,12 @@ describe('Given AuthoritiesSearch', () => {
       expect(mockHistoryPush).toHaveBeenCalledWith('/authorities/cbc03a36-2870-4184-9777-0c44d07edfe4?authRefType=Reference&headingRef=SpringfieldEDITED');
     });
   });
+
+  describe('when Authority record is shared', () => {
+    it('should render shared icon', () => {
+      const { getByText } = renderAuthoritiesSearch({ authorities });
+
+      expect(getByText('stripes-authority-components.search.shared')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Desctiption

## Screenshots
![image](https://github.com/folio-org/ui-marc-authorities/assets/19309423/b8f66abc-cadb-4cd8-b43f-d172411ed370)

## Issues
[UIMARCAUTH-298](https://issues.folio.org/browse/UIMARCAUTH-298)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/97
https://github.com/folio-org/ui-plugin-find-authority/pull/73