### PR TITLE
UIMARCAUTH-305 Change tenant id to central when opening details of Shared Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [UIMARCAUTH-300](https://issues.folio.org/browse/UIMARCAUTH-300) *BREAKING* Bump `react` to `v18`.
 - [UIMARCAUTH-268](https://issues.folio.org/browse/UIMARCAUTH-268) Add "Local" or "Shared" to flag MARC authorities.
 - [UIMARCAUTH-298](https://issues.folio.org/browse/UIMARCAUTH-298) Add Shared icon to MARC authority search results.
+- [UIMARCAUTH-305](https://issues.folio.org/browse/UIMARCAUTH-305) Change tenant id to central when opening details of Shared Authority.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -15,6 +15,7 @@ import omit from 'lodash/omit';
 import {
   useNamespace,
   useCallout,
+  useStripes,
 } from '@folio/stripes/core';
 import {
   SelectedAuthorityRecordContext,
@@ -26,6 +27,7 @@ import { AuthorityView } from '../../views';
 import { QUERY_KEY_AUTHORITY_SOURCE } from '../../constants';
 
 const AuthorityViewRoute = () => {
+  const stripes = useStripes();
   const { params: { id } } = useRouteMatch();
   const location = useLocation();
   const history = useHistory();
@@ -39,6 +41,7 @@ const AuthorityViewRoute = () => {
 
   const headingRef = selectedAuthority?.headingRef || searchParams.headingRef;
   const authRefType = selectedAuthority?.authRefType || searchParams.authRefType;
+  const tenantId = selectedAuthority?.shared ? stripes.user.user.consortium?.centralTenantId : selectedAuthority?.tenantId;
 
   const handleAuthorityLoadError = async err => {
     const errorResponse = await err.response;
@@ -57,10 +60,10 @@ const AuthorityViewRoute = () => {
     });
   };
 
-  const marcSource = useMarcSource(id, {
+  const marcSource = useMarcSource({ recordId: id, tenantId }, {
     onError: handleAuthorityLoadError,
   });
-  const authority = useAuthority(id, authRefType, headingRef, {
+  const authority = useAuthority({ recordId: id, authRefType, headingRef, tenantId }, {
     onError: handleAuthorityLoadError,
   });
 
@@ -68,7 +71,7 @@ const AuthorityViewRoute = () => {
     if (authority && !selectedAuthority) {
       setSelectedAuthority(authority.data);
     }
-  }, [authority.data?.id]);
+  }, [authority?.data?.id]);
 
   return (
     <AuthorityView

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -53,6 +53,7 @@ const propTypes = {
       id: PropTypes.string,
       numberOfTitles: PropTypes.number,
       shared: PropTypes.bool,
+      tenantId: PropTypes.string,
     }),
     isLoading: PropTypes.bool.isRequired,
   }).isRequired,
@@ -71,8 +72,9 @@ const AuthorityView = ({
   const history = useHistory();
   const location = useLocation();
   const stripes = useStripes();
+  const tenantId = authority.data?.shared ? stripes.user.user.consortium?.centralTenantId : authority.data?.tenantId;
 
-  const { authorityMappingRules } = useAuthorityMappingRules();
+  const { authorityMappingRules } = useAuthorityMappingRules({ tenantId, enabled: Boolean(authority.data) });
 
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
@@ -198,6 +200,7 @@ const AuthorityView = ({
         marcTitle={marcTitle}
         marc={markHighlightedFields(marcSource, authority, authorityMappingRules).data}
         onClose={onClose}
+        tenantId={authority.data.tenantId}
         lastMenu={
           <>
             {(hasEditPermission || hasDeletePermission) && (

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -33,6 +33,9 @@ const buildStripes = (otherProperties = {}) => ({
     user: {
       id: 'b1add99d-530b-5912-94f3-4091b4d87e2c',
       username: 'diku_admin',
+      consortium: {
+        centralTenantId: 'consortia',
+      },
     },
   },
   withOkapi: true,


### PR DESCRIPTION
## Description
Change tenant id to central when opening details of Shared Authority

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/19309423/27ac5297-047d-4dca-abec-63679201f8bf



## Issues
[UIMARCAUTH-305](https://issues.folio.org/browse/UIMARCAUTH-305)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/74
https://github.com/folio-org/stripes-authority-components/pull/99
https://github.com/folio-org/ui-quick-marc/pull/580