### PR TITLE
UIMARCAUTH-297: Don't clear previous Search/Browse results to highlight the edited record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [UIMARCAUTH-313](https://issues.folio.org/browse/UIMARCAUTH-313) Load MARC Authority source file with authority record's `tenantId`.
 - [UIMARCAUTH-285](https://issues.folio.org/browse/UIMARCAUTH-285) Edit Shared MARC authority record, update Shared & Local Instances.
 - [UIMARCAUTH-321](https://issues.folio.org/browse/UIMARCAUTH-321) *BREAKING* bump `react-intl` to `v6.4.4`.
+- [UIMARCAUTH-297](https://issues.folio.org/browse/UIMARCAUTH-297) Don't clear previous Search/Browse results to highlight the edited record.
 
 ## [3.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v3.0.2) (2023-03-24)
 

--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -8,7 +8,6 @@ import {
   AuthoritiesSearchContext,
   SelectedAuthorityRecordContext,
   useAuthoritiesBrowse,
-  useBrowseResultFocus,
 } from '@folio/stripes-authority-components';
 
 import { AuthoritiesSearch } from '../../views';
@@ -63,13 +62,6 @@ const BrowseRoute = ({ children }) => {
     navigationSegmentValue,
   });
 
-  const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);
-
-  const handleNeedMoreData = (...params) => {
-    isPaginationClicked.current = true;
-    handleLoadMore(...params);
-  };
-
   const onSubmitSearch = e => {
     if (e && e.preventDefault) {
       e.preventDefault();
@@ -106,9 +98,9 @@ const BrowseRoute = ({ children }) => {
       isLoaded={isLoaded}
       query={query}
       pageSize={PAGE_SIZE}
-      resultsContainerRef={resultsContainerRef}
+      pagingOffset={0} // any number allows to always focus on the first row after the pagination change.
       onSubmitSearch={onSubmitSearch}
-      handleLoadMore={handleNeedMoreData}
+      handleLoadMore={handleLoadMore}
       hidePageIndices
     >
       {children}

--- a/src/routes/BrowseRoute/BrowseRoute.test.js
+++ b/src/routes/BrowseRoute/BrowseRoute.test.js
@@ -2,9 +2,7 @@ import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
 
-import {
-  useAuthoritiesBrowse,
-} from '@folio/stripes-authority-components';
+import { useAuthoritiesBrowse } from '@folio/stripes-authority-components';
 import BrowseRoute from './BrowseRoute';
 import Harness from '../../../test/jest/helpers/harness';
 import { AuthoritiesSearch } from '../../views';

--- a/src/routes/BrowseRoute/BrowseRoute.test.js
+++ b/src/routes/BrowseRoute/BrowseRoute.test.js
@@ -4,19 +4,16 @@ import { runAxeTest } from '@folio/stripes-testing';
 
 import {
   useAuthoritiesBrowse,
-  useBrowseResultFocus,
 } from '@folio/stripes-authority-components';
 import BrowseRoute from './BrowseRoute';
 import Harness from '../../../test/jest/helpers/harness';
 import { AuthoritiesSearch } from '../../views';
 
-const mockIsPaginationClicked = { current: false };
 const mockHandleLoadMore = jest.fn();
 
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useAuthoritiesBrowse: jest.fn(),
-  useBrowseResultFocus: jest.fn(),
 }));
 
 jest.mock('../../views', () => ({
@@ -38,8 +35,6 @@ const renderBrowseRoute = () => render(
 
 describe('Given BrowseRoute', () => {
   beforeEach(() => {
-    mockIsPaginationClicked.current = false;
-
     useAuthoritiesBrowse.mockReturnValue({
       authorities: [],
       hasNextPage: false,
@@ -49,11 +44,6 @@ describe('Given BrowseRoute', () => {
       handleLoadMore: mockHandleLoadMore,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       totalRecords: 0,
-    });
-
-    useBrowseResultFocus.mockReturnValue({
-      resultsContainerRef: { current: null },
-      isPaginationClicked: mockIsPaginationClicked,
     });
   });
 
@@ -76,14 +66,13 @@ describe('Given BrowseRoute', () => {
   });
 
   describe('when a user clicks on the pagination button', () => {
-    it('should invoke handleLoadMore and assign isPaginationClicked to true', () => {
+    it('should invoke handleLoadMore', () => {
       const args = [100, 95, 0, 'next'];
 
       renderBrowseRoute();
       AuthoritiesSearch.mock.calls[0][0].handleLoadMore(...args);
 
       expect(mockHandleLoadMore).toHaveBeenCalledWith(...args);
-      expect(mockIsPaginationClicked.current).toBeTruthy();
     });
   });
 });

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -93,6 +93,7 @@ const propTypes = {
   onHeaderClick: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
+  pagingOffset: PropTypes.number,
   query: PropTypes.string,
   totalRecords: PropTypes.number.isRequired,
 };
@@ -663,6 +664,7 @@ AuthoritiesSearch.defaultProps = {
   query: '',
   hasNextPage: null,
   hasPrevPage: null,
+  pagingOffset: null,
 };
 
 export default AuthoritiesSearch;

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -94,7 +94,6 @@ const propTypes = {
   onSubmitSearch: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   query: PropTypes.string,
-  resultsContainerRef: PropTypes.object,
   totalRecords: PropTypes.number.isRequired,
 };
 
@@ -108,7 +107,7 @@ const AuthoritiesSearch = ({
   totalRecords,
   query,
   pageSize,
-  resultsContainerRef,
+  pagingOffset,
   onSubmitSearch,
   hidePageIndices,
   hasNextPage,
@@ -630,7 +629,7 @@ const AuthoritiesSearch = ({
           hasPrevPage={hasPrevPage}
           totalResults={totalRecords}
           pageSize={pageSize}
-          resultsContainerRef={resultsContainerRef}
+          pagingOffset={pagingOffset}
           onNeedMoreData={handleLoadMore}
           loading={isLoading}
           loaded={isLoaded}
@@ -664,7 +663,6 @@ AuthoritiesSearch.defaultProps = {
   query: '',
   hasNextPage: null,
   hasPrevPage: null,
-  resultsContainerRef: null,
 };
 
 export default AuthoritiesSearch;

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -664,7 +664,7 @@ AuthoritiesSearch.defaultProps = {
   query: '',
   hasNextPage: null,
   hasPrevPage: null,
-  pagingOffset: null,
+  pagingOffset: undefined, // undefined is required
 };
 
 export default AuthoritiesSearch;


### PR DESCRIPTION
## Purpose
Don't clear previous Search/Browse results to highlight the edited record.

## Approach
Keeping previous results fixes the current issue, but occasionally leads to incorrect row focus in the `Browse` search after clicking the pagination buttons (when the previous page has fewer results than the next one) ([UIPFAUTH-51](https://issues.folio.org/browse/UIPFAUTH-51)) 

The newly added `pagingOffset` prop in the `stripes-components` allows always focus on the first row after pagination buttons are clicked.

## Issue
[UIMARCAUTH-297](https://issues.folio.org/browse/UIMARCAUTH-297)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/78
https://github.com/folio-org/stripes-authority-components/pull/110

## Screencast



https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/7a7cc127-434c-48b3-ba69-67d06402e27d


