### PR TITLE
UIMARCAUTH-343: Add new column called Authority source for the browse and search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.0.0] IN PROGRESS
 
 - [UIMARCAUTH-339](https://issues.folio.org/browse/UIMARCAUTH-339) *BREAKING* Replace imports from quick-marc with stripes-marc-components.
+- [UIMARCAUTH-343](https://issues.folio.org/browse/UIMARCAUTH-343) Add new column called Authority source for the browse and search results.
 
 ## [4.1.0] IN PROGRESS
 

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -1,2 +1,1 @@
 export const QUERY_KEY_AUTHORITIES = 'authorities';
-export const QUERY_KEY_AUTHORITY_SOURCE = 'authority-source';

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -21,10 +21,10 @@ import {
   SelectedAuthorityRecordContext,
   useMarcSource,
   useAuthority,
+  QUERY_KEY_AUTHORITY_SOURCE,
 } from '@folio/stripes-authority-components';
 
 import { AuthorityView } from '../../views';
-import { QUERY_KEY_AUTHORITY_SOURCE } from '../../constants';
 
 const AuthorityViewRoute = () => {
   const stripes = useStripes();

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -209,6 +209,7 @@ const AuthoritiesSearch = ({
     [searchResultListColumns.AUTH_REF_TYPE]: <FormattedMessage id="stripes-authority-components.search-results-list.authRefType" />,
     [searchResultListColumns.HEADING_REF]: <FormattedMessage id="stripes-authority-components.search-results-list.headingRef" />,
     [searchResultListColumns.HEADING_TYPE]: <FormattedMessage id="stripes-authority-components.search-results-list.headingType" />,
+    [searchResultListColumns.AUTHORITY_SOURCE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.authoritySource' }),
     [searchResultListColumns.NUMBER_OF_TITLES]: <FormattedMessage id="ui-marc-authorities.search-results-list.numberOfTitles" />,
   }), [selectAll, selectAllLabel, toggleSelectAll]);
 
@@ -622,6 +623,7 @@ const AuthoritiesSearch = ({
             [searchResultListColumns.AUTH_REF_TYPE]: '200px',
             [searchResultListColumns.HEADING_REF]: '600px',
             [searchResultListColumns.HEADING_TYPE]: '200px',
+            [searchResultListColumns.AUTHORITY_SOURCE]: '250px',
           }}
           formatter={formatter}
           hasNextPage={hasNextPage}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -40,6 +40,10 @@ jest.mock('@folio/stripes-authority-components', () => ({
       <button type="button" data-testid="reset-all" onClick={() => props.resetSelectedRows()}>Reset all</button>
     </div>
   ),
+  useAuthoritySourceFiles: jest.fn().mockReturnValue({
+    isLoading: false,
+    sourceFiles: [],
+  }),
 }));
 
 jest.mock('../../hooks', () => ({
@@ -85,6 +89,7 @@ const renderAuthoritiesSearch = (...params) => render(getAuthoritiesSearch(...pa
 
 describe('Given AuthoritiesSearch', () => {
   beforeEach(() => {
+    sessionStorage.clear();
     useSortColumnManager.mockImplementation(jest.requireActual('../../hooks').useSortColumnManager);
   });
 
@@ -476,5 +481,15 @@ describe('Given AuthoritiesSearch', () => {
 
       expect(getByText('stripes-authority-components.search.shared')).toBeInTheDocument();
     });
+  });
+
+  it('should display columns', () => {
+    const { getByRole } = renderAuthoritiesSearch({ authorities });
+
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authRefType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingRef' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authoritySource' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'ui-marc-authorities.search-results-list.numberOfTitles' })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose
Add a new column called `Authority source` for the browse and search results.

## Issues
[UIMARCAUTH-343](https://issues.folio.org/browse/UIMARCAUTH-343)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/86
https://github.com/folio-org/stripes-authority-components/pull/126

## Screencast

https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/bff2f1fc-c3db-4f80-b907-2ca0effa6978

