### PR TITLE
UIMARCAUTH-351 Clear selected authority record data before opening another one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UIMARCAUTH-339](https://issues.folio.org/browse/UIMARCAUTH-339) *BREAKING* Replace imports from quick-marc with stripes-marc-components.
 - [UIMARCAUTH-343](https://issues.folio.org/browse/UIMARCAUTH-343) Add new column called Authority source for the browse and search results.
 - [UIMARCAUTH-352](https://issues.folio.org/browse/UIMARCAUTH-352) Change create MARC authority action label.
+- [UIMARCAUTH-351](https://issues.folio.org/browse/UIMARCAUTH-351) Clear selected authority record data before opening another one.
 
 ## [4.1.0] IN PROGRESS
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -431,6 +431,7 @@ const AuthoritiesSearch = ({
   }, [match.path, location.search]);
 
   const redirectToAuthorityRecord = useCallback(authority => {
+    setSelectedAuthorityRecord(null);
     history.push(formatAuthorityRecordLink(authority));
   }, [history, formatAuthorityRecordLink]);
 


### PR DESCRIPTION
## Description
ECS | "Authority record not found" error appears when only one record is returned to the result list after applied facet.
Issue was caused by previous open record data present which triggered fetch of a new MARC record with previous record's tenant.
Clear selected authority record data before opening another one.

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/19309423/e7716b7b-f2c2-4818-b551-632cfa88f94b

## Issues
[UIMARCAUTH-351](https://issues.folio.org/browse/UIMARCAUTH-351)