### PR TITLE
UIMARCAUTH-353 Use first page Browse query for facet requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UIMARCAUTH-343](https://issues.folio.org/browse/UIMARCAUTH-343) Add new column called Authority source for the browse and search results.
 - [UIMARCAUTH-352](https://issues.folio.org/browse/UIMARCAUTH-352) Change create MARC authority action label.
 - [UIMARCAUTH-351](https://issues.folio.org/browse/UIMARCAUTH-351) Clear selected authority record data before opening another one.
+- [UIMARCAUTH-353](https://issues.folio.org/browse/UIMARCAUTH-353) Use first page Browse query for facet requests
 
 ## [4.1.0] IN PROGRESS
 

--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -48,6 +48,7 @@ const BrowseRoute = ({ children }) => {
     isLoaded,
     handleLoadMore,
     query,
+    firstPageQuery,
     totalRecords,
   } = useAuthoritiesBrowse({
     filters,
@@ -97,6 +98,7 @@ const BrowseRoute = ({ children }) => {
       isLoading={isLoading}
       isLoaded={isLoaded}
       query={query}
+      firstPageQuery={firstPageQuery}
       pageSize={PAGE_SIZE}
       onSubmitSearch={onSubmitSearch}
       handleLoadMore={handleLoadMore}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -84,6 +84,7 @@ const propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
+  firstPageQuery: PropTypes.string.isRequired,
   handleLoadMore: PropTypes.func.isRequired,
   hasNextPage: PropTypes.bool,
   hasPrevPage: PropTypes.bool,
@@ -106,6 +107,7 @@ const AuthoritiesSearch = ({
   isLoaded,
   totalRecords,
   query,
+  firstPageQuery,
   pageSize,
   onSubmitSearch,
   hidePageIndices,
@@ -601,7 +603,7 @@ const AuthoritiesSearch = ({
         isLoading={isLoading}
         onSubmitSearch={onSubmitSearch}
         resetSelectedRows={resetSelectedRows}
-        query={query}
+        query={firstPageQuery}
         hasAdvancedSearch
       />
       <Pane


### PR DESCRIPTION
## Description
Fix Facet counts changing when going Next or Prev page in Browse
Use first page query to fetch Browse facets

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/19309423/642eae73-ff96-49de-893b-52db1fe0064d


## Issues
[UIMARCAUTH-353](https://issues.folio.org/browse/UIMARCAUTH-353)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/88
https://github.com/folio-org/stripes-authority-components/pull/130