### PR TITLE
UIMARCAUTH-336 Show  permissions for creating new authority record via UI (Q release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UIMARCAUTH-343](https://issues.folio.org/browse/UIMARCAUTH-343) Add new column called Authority source for the browse and search results.
 - [UIMARCAUTH-352](https://issues.folio.org/browse/UIMARCAUTH-352) Change create MARC authority action label.
 - [UIMARCAUTH-351](https://issues.folio.org/browse/UIMARCAUTH-351) Clear selected authority record data before opening another one.
+- [UIMARCAUTH-336](https://issues.folio.org/browse/UIMARCAUTH-336) Show  permissions for creating new authority record via UI.
 
 ## [4.1.0] IN PROGRESS
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
           "instance-authority-links.authorities.bulk.post",
           "marc-records-editor.status.item.get"
         ],
-        "visible": false
+        "visible": true
       },
       {
         "permissionName": "ui-marc-authorities.authority-record.edit",

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -43,6 +43,7 @@ import {
   AppIcon,
   useNamespace,
   CalloutContext,
+  IfPermission,
 } from '@folio/stripes/core';
 import { buildSearch } from '@folio/stripes-acq-components';
 import {
@@ -486,8 +487,7 @@ const AuthoritiesSearch = ({
             />
             <FormattedMessage id="ui-marc-authorities.export-selected-records" />
           </Button>
-          {/* Uncomment when Create Authority feature should be included in release */}
-          {/* <IfPermission perm="ui-marc-authorities.authority-record.create">
+          <IfPermission perm="ui-marc-authorities.authority-record.create">
             <Button
               buttonStyle="dropdownItem"
               id="dropdown-clickable-create-authority"
@@ -497,7 +497,7 @@ const AuthoritiesSearch = ({
                 <FormattedMessage id="ui-marc-authorities.actions.create" />
               </Icon>
             </Button>
-          </IfPermission> */}
+          </IfPermission>
         </MenuSection>
         {navigationSegmentValue !== navigationSegments.browse &&
           <MenuSection


### PR DESCRIPTION
## Description
Show  permissions for creating new authority record via UI (Q release)

## Issues
[UIMARCAUTH-336](https://issues.folio.org/browse/UIMARCAUTH-336)