### PR TITLE
UIMARCAUTH-363 Counter values and options for Authority source, Thesaurus facet options do not change when changing search parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-344](https://issues.folio.org/browse/UIMARCAUTH-344) Added permissions for viewing and editing/creating/deleting Authority Source files in Settings
 - [UIMARCAUTH-336](https://issues.folio.org/browse/UIMARCAUTH-336) Show  permissions for creating new authority record via UI.
 - [UIMARCAUTH-295](https://issues.folio.org/browse/UIMARCAUTH-295) Add Search type dropdown to Advanced search modal.
+- [UIMARCAUTH-363](https://issues.folio.org/browse/UIMARCAUTH-363) Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters.
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -603,7 +603,8 @@ const AuthoritiesSearch = ({
         isLoading={isLoading}
         onSubmitSearch={onSubmitSearch}
         resetSelectedRows={resetSelectedRows}
-        query={firstPageQuery}
+        query={query}
+        firstPageQuery={firstPageQuery}
         hasAdvancedSearch
         hasQueryOption={false}
         hasMatchSelection


### PR DESCRIPTION
## Description
Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters
Need to send request to facets with current search query parameters

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/19309423/3f26c69f-ae71-4fc6-ab4e-ea646cdd54f9

## Issues
[UIMARCAUTH-363](https://issues.folio.org/browse/UIMARCAUTH-363)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/136