### PR TITLE
UIMARCAUTH-360 Fix issues creating Authority Source files (follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
           "settings.marc-authorities.enabled",
           "inventory-storage.authority-source-files.collection.get",
           "inventory-storage.authority-source-files.item.get",
-          "perms.users.get"
+          "perms.users.get",
+          "users.collection.get"
         ],
         "visible": true
       },

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
@@ -28,6 +28,11 @@ import { getValidators } from './getValidators';
 
 const authorityFilesAllPerm = 'ui-marc-authorities.settings.authority-files.all';
 
+const ITEM_TEMPLATE = {
+  [authorityFilesColumns.SOURCE]: SOURCES.LOCAL,
+  [authorityFilesColumns.SELECTABLE]: false,
+};
+
 const ManageAuthoritySourceFiles = () => {
   const stripes = useStripes();
   const { formatMessage } = useIntl();
@@ -66,7 +71,12 @@ const ManageAuthoritySourceFiles = () => {
     const fileCopy = { ...file };
 
     fileCopy.code = file.codes;
+    fileCopy.hridManagement = {
+      startNumber: file.startNumber,
+    };
+
     delete fileCopy.codes;
+    delete fileCopy.startNumber;
 
     return fileCopy;
   }, []);
@@ -145,7 +155,7 @@ const ManageAuthoritySourceFiles = () => {
         }}
         readOnlyFields={[authorityFilesColumns.SOURCE]}
         id="authority-source-files"
-        itemTemplate={{ [authorityFilesColumns.SOURCE]: SOURCES.LOCAL }}
+        itemTemplate={ITEM_TEMPLATE}
         fieldComponents={getFieldComponents(selectableFieldLabel)}
         columnWidths={columnWidths}
         actionSuppression={{

--- a/src/settings/ManageAuthoritySourceFiles/getValidators.js
+++ b/src/settings/ManageAuthoritySourceFiles/getValidators.js
@@ -2,10 +2,21 @@ import { FormattedMessage } from 'react-intl';
 
 import { authorityFilesColumns } from './constants';
 
+const CODES_MAX_LENGTH = 25;
+
 const validators = {
   [authorityFilesColumns.CODES]: function validateCodes({ codes, id }, items) {
     if (!codes) {
       return <FormattedMessage id="ui-marc-authorities.settings.manageAuthoritySourceFiles.error.codes.empty" />;
+    }
+
+    if (codes.length > CODES_MAX_LENGTH) {
+      return (
+        <FormattedMessage
+          id="ui-marc-authorities.settings.manageAuthoritySourceFiles.error.codes.length"
+          values={{ maxlength: CODES_MAX_LENGTH }}
+        />
+      );
     }
 
     const codesArray = Array.isArray(codes) ? codes : [codes];

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -91,5 +91,6 @@
   "settings.manageAuthoritySourceFiles.error.codes.onlyOnePrefix": "Error saving data. Only one prefix is allowed for local authority files.",
   "settings.manageAuthoritySourceFiles.error.codes.unique": "Error saving data. Prefix must be unique.",
   "settings.manageAuthoritySourceFiles.error.codes.empty": "Error saving data. Prefix is required.",
+  "settings.manageAuthoritySourceFiles.error.codes.length": "Error saving data. Prefix cannot be more than {maxlength} characters.",
   "settings.manageAuthoritySourceFiles.create.success": "The authority file (name) has been successfully created."
 }


### PR DESCRIPTION
## Description
- Added missing permission to get users from metadata
- Added validation for length of prefix field
- Fix issue with `active` field not being saved

## Issues
[UIMARCAUTH-360](https://issues.folio.org/browse/UIMARCAUTH-360)