### PR TITLE
UIMARCAUTH-374 Use `onSave` prop for quickMARC to handle saving records separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [UIMARCAUTH-363](https://issues.folio.org/browse/UIMARCAUTH-363) Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters.
 - [UIMARCAUTH-337](https://issues.folio.org/browse/UIMARCAUTH-337) Add `Manage authority files` settings.
 - [UIMARCAUTH-360](https://issues.folio.org/browse/UIMARCAUTH-360) Implement creation of Authority Source Files.
+- [UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-374) Use `onSave` prop for quickMARC to handle saving records separately.
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/src/routes/AuthorityQuickMarcRoute/AuthorityQuickMarcRoute.js
+++ b/src/routes/AuthorityQuickMarcRoute/AuthorityQuickMarcRoute.js
@@ -27,12 +27,6 @@ const AuthorityQuickMarcRoute = () => {
   const { setIsGoingToBaseURL } = useContext(AuthoritiesSearchContext);
 
   const onClose = useCallback(async recordId => {
-    if (recordId) {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-
-      await queryClient.invalidateQueries(namespace);
-    }
-
     setIsGoingToBaseURL(false);
 
     history.push({
@@ -40,13 +34,24 @@ const AuthorityQuickMarcRoute = () => {
       search: location.search,
       state: { editSuccessful: true },
     });
-  }, [namespace, queryClient, setIsGoingToBaseURL, location.search, history]);
+  }, [setIsGoingToBaseURL, location.search, history]);
+
+  const onSave = useCallback(async recordId => {
+    if (recordId) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      await queryClient.invalidateQueries(namespace);
+    }
+
+    onClose(recordId);
+  }, [onClose, namespace, queryClient]);
 
   return (
     <Pluggable
       type="quick-marc"
       basePath={match.path}
       onClose={onClose}
+      onSave={onSave}
       externalRecordPath="/marc-authorities/authorities"
     >
       <FormattedMessage id="ui-inventory.quickMarcNotAvailable" />


### PR DESCRIPTION
## Description
New `onSave` prop for quickMARC is added to handle saving and closing records without save separately

## Issues
[UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-374)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/648