### PR TITLE
UIMARCAUTH-359 Changed implementation for basic creating/updating logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [UIMARCAUTH-337](https://issues.folio.org/browse/UIMARCAUTH-337) Add `Manage authority files` settings.
 - [UIMARCAUTH-360](https://issues.folio.org/browse/UIMARCAUTH-360) Implement creation of Authority Source Files.
 - [UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-374) Use `onSave` prop for quickMARC to handle saving records separately.
-- [UIMARCAUTH-350](https://issues.folio.org/browse/UIMARCAUTH-359) EDIT | Create new settings options for configuring authority files
+- [UIMARCAUTH-359](https://issues.folio.org/browse/UIMARCAUTH-359) EDIT | Create new settings options for configuring authority files
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [UIMARCAUTH-337](https://issues.folio.org/browse/UIMARCAUTH-337) Add `Manage authority files` settings.
 - [UIMARCAUTH-360](https://issues.folio.org/browse/UIMARCAUTH-360) Implement creation of Authority Source Files.
 - [UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-374) Use `onSave` prop for quickMARC to handle saving records separately.
+- [UIMARCAUTH-350](https://issues.folio.org/browse/UIMARCAUTH-359) EDIT | Create new settings options for configuring authority files
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.js
@@ -3,14 +3,15 @@ import {
   useQueryClient,
 } from 'react-query';
 
-import { useNamespace } from '@folio/stripes/core';
-
-import { useTenantKy } from '@folio/stripes-authority-components';
+import {
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
 
 import { QUERY_KEY_AUTHORITIES } from '../../constants';
 
 const useAuthorityDelete = ({ onError, onSuccess, tenantId, ...restOptions }) => {
-  const ky = useTenantKy({ tenantId });
+  const ky = useOkapiKy({ tenant: tenantId });
   const queryClient = useQueryClient();
   const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITIES });
 

--- a/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
+++ b/src/queries/useAuthoritiesDelete/useAuthorityDelete.test.js
@@ -6,13 +6,8 @@ import {
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 
-import { useTenantKy } from '@folio/stripes-authority-components';
+import { useOkapiKy } from '@folio/stripes/core';
 import useAuthorityDelete from './useAuthorityDelete';
-
-jest.mock('@folio/stripes-authority-components', () => ({
-  ...jest.requireActual('@folio/stripes-authority-components'),
-  useTenantKy: jest.fn(),
-}));
 
 const queryClient = new QueryClient();
 
@@ -33,7 +28,7 @@ describe('useAuthorityDeleteMutation', () => {
     const deleteMock = jest.fn().mockResolvedValue({});
     const successMock = jest.fn();
 
-    useTenantKy.mockClear().mockReturnValue({
+    useOkapiKy.mockClear().mockReturnValue({
       delete: deleteMock,
     });
 
@@ -54,7 +49,7 @@ describe('useAuthorityDeleteMutation', () => {
     const deleteMock = jest.fn().mockRejectedValue(new Error('Async error'));
     const errorMock = jest.fn();
 
-    useTenantKy.mockClear().mockReturnValue({
+    useOkapiKy.mockClear().mockReturnValue({
       delete: deleteMock,
     });
 

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.css
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.css
@@ -1,0 +1,3 @@
+.lastUpdated {
+  width: stretch;
+}

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
@@ -167,16 +167,7 @@ const ManageAuthoritySourceFiles = () => {
     );
   }, [updaters]);
 
-  const formatter = useMemo(() => ({
-    ...getFormatter({ selectableFieldLabel }),
-    [authorityFilesColumns.LAST_UPDATED]: item => {
-      if (item.metadata) {
-        return renderLastUpdated(item.metadata);
-      }
-
-      return '-';
-    },
-  }), [selectableFieldLabel, renderLastUpdated]);
+  const formatter = useMemo(() => getFormatter({ selectableFieldLabel, renderLastUpdated }), [selectableFieldLabel, renderLastUpdated]);
 
   const isEmptyMessage = useMemo(() => (
     isLoading

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
@@ -45,7 +45,7 @@ const ACTION_TYPES = {
 };
 
 const ManageAuthoritySourceFiles = () => {
-  const { formatMessage } = useIntl();
+  const intl = useIntl();
   const callout = useCallout();
 
   const showSuccessMessage = (action, name) => callout.sendCallout({
@@ -86,9 +86,9 @@ const ManageAuthoritySourceFiles = () => {
     onUpdateFail,
   });
 
-  const paneTitle = formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.pane.title' });
-  const label = formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.list.label' });
-  const selectableFieldLabel = formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable' });
+  const paneTitle = intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.pane.title' });
+  const label = intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.list.label' });
+  const selectableFieldLabel = intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable' });
 
   const getRequiredLabel = useCallback(columnLabel => (
     <Label required>
@@ -113,21 +113,21 @@ const ManageAuthoritySourceFiles = () => {
   ]), []);
 
   const columnMapping = useMemo(() => ({
-    [authorityFilesColumns.NAME]: getRequiredLabel(formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.name' })),
-    [authorityFilesColumns.CODES]: getRequiredLabel(formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.codes' })),
-    [authorityFilesColumns.START_NUMBER]: getRequiredLabel(formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.startNumber' })),
-    [authorityFilesColumns.BASE_URL]: formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.baseUrl' }),
+    [authorityFilesColumns.NAME]: getRequiredLabel(intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.name' })),
+    [authorityFilesColumns.CODES]: getRequiredLabel(intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.codes' })),
+    [authorityFilesColumns.START_NUMBER]: getRequiredLabel(intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.startNumber' })),
+    [authorityFilesColumns.BASE_URL]: intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.baseUrl' }),
     [authorityFilesColumns.SELECTABLE]: (
       <>
         {selectableFieldLabel}
         <InfoPopover
-          content={formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable.info' })}
+          content={intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable.info' })}
         />
       </>
     ),
-    [authorityFilesColumns.SOURCE]: formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.source' }),
-    [authorityFilesColumns.LAST_UPDATED]: formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.lastUpdated' }),
-  }), [formatMessage, selectableFieldLabel, getRequiredLabel]);
+    [authorityFilesColumns.SOURCE]: intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.source' }),
+    [authorityFilesColumns.LAST_UPDATED]: intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.lastUpdated' }),
+  }), [intl, selectableFieldLabel, getRequiredLabel]);
 
   const columnWidths = useMemo(() => ({
     [authorityFilesColumns.NAME]: '300px',
@@ -209,7 +209,7 @@ const ManageAuthoritySourceFiles = () => {
           formType="final-form"
           contentData={sourceFiles}
           totalCount={sourceFiles.length}
-          createButtonLabel={formatMessage({ id: 'stripes-core.button.new' })}
+          createButtonLabel={intl.formatMessage({ id: 'stripes-core.button.new' })}
           label={label}
           itemTemplate={ITEM_TEMPLATE}
           visibleFields={visibleFields}
@@ -228,7 +228,7 @@ const ManageAuthoritySourceFiles = () => {
           onSubmit={noop}
           isEmptyMessage={isEmptyMessage}
           validate={(item, _index, items) => validate(item, items)}
-          fieldComponents={getFieldComponents(selectableFieldLabel)}
+          fieldComponents={getFieldComponents(selectableFieldLabel, intl)}
           columnWidths={columnWidths}
           canCreate={canCreate}
         />

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.test.js
@@ -1,113 +1,65 @@
-import { fireEvent, render } from '@folio/jest-config-stripes/testing-library/react';
-
-import stripesSmartComponents from '@folio/stripes/smart-components';
-import { useUserTenantPermissions } from '@folio/stripes-authority-components';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import Harness from '../../../test/jest/helpers/harness';
 
 import { ManageAuthoritySourceFiles } from './ManageAuthoritySourceFiles';
+import { useManageAuthoritySourceFiles } from './useManageAuthoritySourceFiles';
 
-const { ControlledVocab } = stripesSmartComponents;
+jest.mock('./useManageAuthoritySourceFiles', () => ({
+  useManageAuthoritySourceFiles: jest.fn(),
+}));
 
-const authoritySourceFiles = [
-  {
-    'id': 'cb58492d-018e-442d-9ce3-35aabfc524aa',
-    'name': 'Art & architecture thesaurus (AAT)',
-    'codes': ['aat', 'aatg'],
-    'type': 'Subjects',
-    'baseUrl': 'vocab.getty.edu/aat/',
-    'source': 'folio',
-    'selectable': false,
-    'hridManagement': {},
-    'metadata': {
-      'createdDate': '2023-10-16T22:27:18.596598Z',
-      'createdByUserId': '00000000-0000-0000-0000-000000000000',
-      'updatedDate': '2023-10-16T22:27:18.596598Z',
-      'updatedByUserId': '00000000-0000-0000-0000-000000000000',
-    },
+const sourceFiles = [{
+  name: 'Source file 1',
+  codes: ['aa', 'ab'],
+  baseUrl: 'http://test-url-1',
+  selectable: false,
+  source: 'folio',
+  hridManagement: {},
+  metadata: {
+    updatedDate: '2024-01-05T10:35:07.193+00:00',
+    updatedByUserId: 'user-1',
   },
-  {
-    'id': 'af045f2f-e851-4613-984c-4bc13430333a',
-    'name': 'Source option created by USER',
-    'codes': ['unqe'],
-    'type': 'Names',
-    'baseUrl': 'id.loc.gov/authorities/unique/',
-    'source': 'local',
-    'selectable': true,
-    'hridManagement': {
-      startNumber: 100,
-    },
-    'metadata': {
-      'createdDate': '2023-11-27T07:33:54.626664Z',
-      'createdByUserId': '8af55289-9f7f-4680-834f-1b320c8be518',
-      'updatedDate': '2023-11-27T07:33:54.626664Z',
-      'updatedByUserId': '8af55289-9f7f-4680-834f-1b320c8be518',
-    },
+}, {
+  name: 'Source file 2',
+  codes: ['a'],
+  baseUrl: 'http://test-url-2',
+  selectable: true,
+  source: 'local',
+  hridManagement: {
+    startNumber: 100,
   },
-];
-
-const updaters = [
-  {
-    'username': 'ECSAdmin',
-    'id': '8af55289-9f7f-4680-834f-1b320c8be518',
-    'active': true,
-    'type': 'staff',
-    'patronGroup': '3684a786-6671-4268-8ed0-9db82ebca60b',
-    'departments': [],
-    'proxyFor': [],
-    'personal': {
-      'lastName': 'Admin',
-      'firstName': 'ECS',
-      'email': 'ecsadmin@example.com',
-      'addresses': [],
-      'preferredContactTypeId': '002',
-    },
-    'expirationDate': '2025-11-15T23:59:59.000+00:00',
-    'createdDate': '2023-11-15T22:42:14.653+00:00',
-    'updatedDate': '2023-11-15T22:42:14.653+00:00',
-    'metadata': {
-      'createdDate': '2023-11-15T22:40:53.811+00:00',
-      'createdByUserId': '9f9d1c46-52e1-4bb7-9c6c-56e6bb945c42',
-      'updatedDate': '2023-11-15T22:42:14.649+00:00',
-      'updatedByUserId': '9f9d1c46-52e1-4bb7-9c6c-56e6bb945c42',
-    },
-    'customFields': {},
+  metadata: {
+    updatedDate: '2024-01-05T10:35:07.193+00:00',
+    updatedByUserId: '00000000-0000-0000-0000-000000000000',
   },
-];
+}];
 
-jest.spyOn(stripesSmartComponents, 'ControlledVocab').mockImplementation(props => {
-  return (
-    <ControlledVocab
-      mutator={{
-        values: {
-          POST: jest.fn().mockResolvedValue(),
-        },
-      }}
-      resources={{
-        values: {
-          isPending: false,
-          records: authoritySourceFiles,
-        },
-        updaters: {
-          isPending: false,
-          records: updaters,
-        },
-      }}
-      {...props}
-    />
-  );
-});
+const updaters = [{
+  id: 'user-1',
+  personal: {
+    firstName: 'User',
+    lastName: 'Test',
+  },
+}];
 
 const renderManageAuthoritySourceFiles = () => render(<ManageAuthoritySourceFiles />, { wrapper: Harness });
 
 describe('Given Settings', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useUserTenantPermissions.mockImplementation((_, { enabled }) => {
-      if (!enabled) return { userPermissions: [] };
-      return {
-        userPermissions: [{ permissionName: 'ui-marc-authorities.settings.authority-files.all' }],
-      };
+    useManageAuthoritySourceFiles.mockClear().mockReturnValue({
+      sourceFiles,
+      updaters,
+      canEdit: true,
+      canCreate: true,
+      canDelete: true,
+      isLoading: false,
+      validate: jest.fn(),
+      getReadOnlyFieldsForItem: jest.fn().mockReturnValue([]),
+      createFile: jest.fn(),
+      updateFile: jest.fn(),
+      deleteFile: jest.fn(),
     });
   });
 
@@ -139,35 +91,35 @@ describe('Given Settings', () => {
   it('should display correct values in rows', () => {
     const { getByRole, getAllByRole, getAllByText } = renderManageAuthoritySourceFiles();
 
-    expect(getByRole('gridcell', { name: 'Art & architecture thesaurus (AAT)' })).toBeVisible();
-    expect(getByRole('gridcell', { name: 'aat,aatg' })).toBeVisible();
-    expect(getByRole('gridcell', { name: 'vocab.getty.edu/aat/' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'Source file 1' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'aa,ab' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'http://test-url-1' })).toBeVisible();
     expect(getAllByRole('checkbox', { name: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable' })[0]).toBeVisible();
     expect(getByRole('gridcell', { name: 'FOLIO' })).toBeVisible();
     expect(getAllByText('stripes-smart-components.cv.updatedAtAndBy')[0]).toBeVisible();
 
-    expect(getByRole('gridcell', { name: 'Source option created by USER' })).toBeVisible();
-    expect(getByRole('gridcell', { name: 'unqe' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'Source file 2' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'a' })).toBeVisible();
     expect(getByRole('gridcell', { name: '100' })).toBeVisible();
-    expect(getByRole('gridcell', { name: 'id.loc.gov/authorities/unique/' })).toBeVisible();
+    expect(getByRole('gridcell', { name: 'http://test-url-2' })).toBeVisible();
     expect(getAllByRole('checkbox', { name: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.selectable' })[1]).toBeVisible();
     expect(getByRole('gridcell', { name: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.source.local' })).toBeVisible();
     expect(getAllByText('stripes-smart-components.cv.updatedAtAndBy')[1]).toBeVisible();
   });
 
-  describe('when creating a new Source File', () => {
-    describe('and filling in invalid data', () => {
-      it('should show error messages', async () => {
-        const {
-          getByText,
-          getByRole,
-        } = renderManageAuthoritySourceFiles();
+  // describe('when creating a new Source File', () => {
+  //   describe('and filling in invalid data', () => {
+  //     it('should show error messages', async () => {
+  //       const {
+  //         getByText,
+  //         getByRole,
+  //       } = renderManageAuthoritySourceFiles();
 
-        await fireEvent.click(getByRole('button', { name: 'stripes-core.button.new' }));
-        await fireEvent.click(getByRole('button', { name: 'stripes-core.button.save' }));
+  //       await fireEvent.click(getByRole('button', { name: 'stripes-core.button.new' }));
+  //       await fireEvent.click(getByRole('button', { name: 'stripes-core.button.save' }));
 
-        expect(getByText('ui-marc-authorities.settings.manageAuthoritySourceFiles.error.codes.empty')).toBeDefined();
-      });
-    });
-  });
+  //       expect(getByText('ui-marc-authorities.settings.manageAuthoritySourceFiles.error.codes.empty')).toBeDefined();
+  //     });
+  //   });
+  // });
 });

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.test.js
@@ -106,20 +106,4 @@ describe('Given Settings', () => {
     expect(getByRole('gridcell', { name: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.source.local' })).toBeVisible();
     expect(getAllByText('stripes-smart-components.cv.updatedAtAndBy')[1]).toBeVisible();
   });
-
-  // describe('when creating a new Source File', () => {
-  //   describe('and filling in invalid data', () => {
-  //     it('should show error messages', async () => {
-  //       const {
-  //         getByText,
-  //         getByRole,
-  //       } = renderManageAuthoritySourceFiles();
-
-  //       await fireEvent.click(getByRole('button', { name: 'stripes-core.button.new' }));
-  //       await fireEvent.click(getByRole('button', { name: 'stripes-core.button.save' }));
-
-  //       expect(getByText('ui-marc-authorities.settings.manageAuthoritySourceFiles.error.codes.empty')).toBeDefined();
-  //     });
-  //   });
-  // });
 });

--- a/src/settings/ManageAuthoritySourceFiles/constants.js
+++ b/src/settings/ManageAuthoritySourceFiles/constants.js
@@ -1,16 +1,20 @@
 export const authorityFilesColumns = {
   NAME: 'name',
   CODES: 'codes',
-  START_NUMBER: 'startNumber',
+  START_NUMBER: 'hridManagement.startNumber',
   BASE_URL: 'baseUrl',
   SELECTABLE: 'selectable',
   SOURCE: 'source',
   LAST_UPDATED: 'lastUpdated',
   ACTIONS: 'actions',
   NUMBER_OF_OBJECTS: 'numberOfObjects',
+  VERSION: '_version',
 };
 
 export const SOURCES = {
   FOLIO: 'folio',
   LOCAL: 'local',
 };
+
+export const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+

--- a/src/settings/ManageAuthoritySourceFiles/getFieldComponents.js
+++ b/src/settings/ManageAuthoritySourceFiles/getFieldComponents.js
@@ -1,11 +1,47 @@
 import { Field } from 'react-final-form';
 
-import { Checkbox } from '@folio/stripes/components';
+import {
+  Checkbox,
+  TextField,
+} from '@folio/stripes/components';
 
 import { authorityFilesColumns } from './constants';
 
 /* eslint-disable react/prop-types */
-export const getFieldComponents = selectableFieldLabel => ({
+/* eslint-disable react/no-multi-comp */
+export const getFieldComponents = (selectableFieldLabel, intl) => ({
+  [authorityFilesColumns.NAME]: ({ fieldProps }) => (
+    <Field
+      {...fieldProps}
+      component={TextField}
+      placeholder={intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.name' })}
+      marginBottom0
+    />
+  ),
+  [authorityFilesColumns.CODES]: ({ fieldProps }) => (
+    <Field
+      {...fieldProps}
+      component={TextField}
+      placeholder={intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.codes' })}
+      marginBottom0
+    />
+  ),
+  [authorityFilesColumns.START_NUMBER]: ({ fieldProps }) => (
+    <Field
+      {...fieldProps}
+      component={TextField}
+      placeholder={intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.startNumber' })}
+      marginBottom0
+    />
+  ),
+  [authorityFilesColumns.BASE_URL]: ({ fieldProps }) => (
+    <Field
+      {...fieldProps}
+      component={TextField}
+      placeholder={intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.column.baseUrl' })}
+      marginBottom0
+    />
+  ),
   [authorityFilesColumns.SELECTABLE]: ({ fieldProps }) => (
     <Field
       {...fieldProps}

--- a/src/settings/ManageAuthoritySourceFiles/getFieldComponents.js
+++ b/src/settings/ManageAuthoritySourceFiles/getFieldComponents.js
@@ -47,6 +47,7 @@ export const getFieldComponents = (selectableFieldLabel, intl) => ({
       {...fieldProps}
       component={Checkbox}
       aria-label={selectableFieldLabel}
+      marginBottom0
     />
   ),
 });

--- a/src/settings/ManageAuthoritySourceFiles/getFormatter.js
+++ b/src/settings/ManageAuthoritySourceFiles/getFormatter.js
@@ -1,11 +1,14 @@
 import { FormattedMessage } from 'react-intl';
 
-import { Checkbox } from '@folio/stripes/components';
+import {
+  Checkbox,
+  NoValue,
+} from '@folio/stripes/components';
 
 import { authorityFilesColumns, SOURCES } from './constants';
 
 /* eslint-disable react/prop-types, react/no-multi-comp */
-export const getFormatter = ({ selectableFieldLabel }) => ({
+export const getFormatter = ({ selectableFieldLabel, renderLastUpdated }) => ({
   [authorityFilesColumns.CODES]: ({ codes }) => (Array.isArray(codes) ? codes.join(',') : codes),
   [authorityFilesColumns.SELECTABLE]: ({ selectable }) => (
     <Checkbox
@@ -25,5 +28,12 @@ export const getFormatter = ({ selectableFieldLabel }) => ({
     }
 
     return source;
+  },
+  [authorityFilesColumns.LAST_UPDATED]: ({ metadata }) => {
+    if (metadata) {
+      return renderLastUpdated(metadata);
+    }
+
+    return <NoValue />;
   },
 });

--- a/src/settings/ManageAuthoritySourceFiles/getValidators.js
+++ b/src/settings/ManageAuthoritySourceFiles/getValidators.js
@@ -43,12 +43,12 @@ const validators = {
 
     return undefined;
   },
-  [authorityFilesColumns.START_NUMBER]: function validateStartNumber({ startNumber }) {
-    if (!startNumber) {
+  [authorityFilesColumns.START_NUMBER]: function validateStartNumber({ hridManagement }) {
+    if (!hridManagement?.startNumber) {
       return <FormattedMessage id="ui-marc-authorities.settings.manageAuthoritySourceFiles.error.startNumber.empty" />;
     }
 
-    if (startNumber.toString()[0] === '0') {
+    if (hridManagement?.startNumber.toString()[0] === '0') {
       return <FormattedMessage id="ui-marc-authorities.settings.manageAuthoritySourceFiles.error.startNumber.zeroes" />;
     }
 

--- a/src/settings/ManageAuthoritySourceFiles/getValidators.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/getValidators.test.js
@@ -56,7 +56,7 @@ describe('getValidators', () => {
   });
 
   describe('validating start number', () => {
-    const validator = getValidators('startNumber');
+    const validator = getValidators('hridManagement.startNumber');
 
     describe('when start number is valid', () => {
       it('should return undefined', () => {

--- a/src/settings/ManageAuthoritySourceFiles/getValidators.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/getValidators.test.js
@@ -61,7 +61,9 @@ describe('getValidators', () => {
     describe('when start number is valid', () => {
       it('should return undefined', () => {
         const item = {
-          startNumber: '1',
+          hridManagement: {
+            startNumber: '1',
+          },
         };
 
         expect(validator(item)).toBeUndefined();
@@ -71,7 +73,9 @@ describe('getValidators', () => {
     describe('when startNumber is empty', () => {
       it('should return an error', () => {
         const item = {
-          startNumber: '',
+          hridManagement: {
+            startNumber: '',
+          },
         };
 
         expect(validator(item).props.id).toEqual('ui-marc-authorities.settings.manageAuthoritySourceFiles.error.startNumber.empty');
@@ -81,7 +85,9 @@ describe('getValidators', () => {
     describe('when start number has leading zeroes', () => {
       it('should return an error', () => {
         const item = {
-          startNumber: '0001',
+          hridManagement: {
+            startNumber: '0001',
+          },
         };
 
         expect(validator(item).props.id).toEqual('ui-marc-authorities.settings.manageAuthoritySourceFiles.error.startNumber.zeroes');

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
@@ -87,12 +87,8 @@ export const useManageAuthoritySourceFiles = ({
     const fileCopy = { ...file };
 
     fileCopy.code = file.codes;
-    fileCopy.hridManagement = {
-      startNumber: file.startNumber,
-    };
 
     delete fileCopy.codes;
-    delete fileCopy.startNumber;
 
     return fileCopy;
   }, []);
@@ -110,7 +106,7 @@ export const useManageAuthoritySourceFiles = ({
 
     return {
       id: file.id,
-      _version: file._version + 1,
+      _version: file._version,
       ...changedFields,
     };
   }, [sourceFiles]);

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
@@ -1,0 +1,156 @@
+import { useCallback } from 'react';
+import isEqual from 'lodash/isEqual';
+
+import {
+  useStripes,
+  checkIfUserInMemberTenant,
+} from '@folio/stripes/core';
+
+import {
+  useUserTenantPermissions,
+  useAuthoritySourceFiles,
+  useUsers,
+} from '@folio/stripes-authority-components';
+
+import { hasCentralTenantPerm } from '../../utils';
+import { SOURCES, authorityFilesColumns } from './constants';
+import { getValidators } from './getValidators';
+
+const authorityFilesAllPerm = 'ui-marc-authorities.settings.authority-files.all';
+
+export const useManageAuthoritySourceFiles = ({
+  onCreateSuccess,
+  onUpdateSuccess,
+  onDeleteSuccess,
+  onCreateFail,
+  onUpdateFail,
+  onDeleteFail,
+}) => {
+  const stripes = useStripes();
+  const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
+  const userId = stripes.user.user?.id;
+
+  const {
+    sourceFiles,
+    isLoading: isSourceFilesLoading,
+    createFile: _createFile,
+    updateFile: _updateFile,
+    deleteFile: _deleteFile,
+  } = useAuthoritySourceFiles({
+    tenantId: centralTenantId || stripes.okapi.tenant,
+    onCreateSuccess,
+    onUpdateSuccess,
+    onDeleteSuccess,
+    onCreateFail,
+    onUpdateFail,
+    onDeleteFail,
+  });
+
+  const updatersIds = [...new Set(sourceFiles
+    .filter(file => file.metadata?.updatedByUserId)
+    .map(file => file.metadata.updatedByUserId)),
+  ];
+
+  const {
+    users: updaters,
+    isLoading: isUpdatersLoading,
+  } = useUsers(updatersIds);
+
+  const {
+    userPermissions: centralTenantPermissions,
+    isFetching: isCentralTenantPermissionsLoading,
+  } = useUserTenantPermissions({
+    userId,
+    tenantId: centralTenantId,
+  }, {
+    enabled: checkIfUserInMemberTenant(stripes),
+  });
+
+  const isUserHasEditPermission = checkIfUserInMemberTenant(stripes)
+    ? hasCentralTenantPerm(centralTenantPermissions, authorityFilesAllPerm)
+    : stripes.hasPerm(authorityFilesAllPerm);
+
+  const validate = useCallback((item, items) => {
+    const errors = Object.values(authorityFilesColumns).reduce((acc, field) => {
+      const error = getValidators(field)?.(item, items);
+
+      if (error) {
+        acc[field] = error;
+      }
+
+      return acc;
+    }, {});
+
+    return errors;
+  }, []);
+
+  const formatFileForCreate = useCallback(file => {
+    const fileCopy = { ...file };
+
+    fileCopy.code = file.codes;
+    fileCopy.hridManagement = {
+      startNumber: file.startNumber,
+    };
+
+    delete fileCopy.codes;
+    delete fileCopy.startNumber;
+
+    return fileCopy;
+  }, []);
+
+  const formatFileForUpdate = useCallback(file => {
+    // PATCH expects only changed fields, otherwise if a record is assigned and we send a field that wasn't updated the request will fail
+    const originalFile = sourceFiles.find(_file => _file.id === file.id);
+    const changedFields = Object.keys(file).reduce((acc, field) => {
+      if (isEqual(originalFile[field], file[field])) {
+        return acc;
+      }
+
+      return { ...acc, [field]: file[field] };
+    }, {});
+
+    return {
+      id: file.id,
+      _version: file._version + 1,
+      ...changedFields,
+    };
+  }, [sourceFiles]);
+
+  const createFile = useCallback(file => _createFile(formatFileForCreate(file)), [_createFile, formatFileForCreate]);
+  const updateFile = useCallback(file => _updateFile(formatFileForUpdate(file)), [_updateFile, formatFileForUpdate]);
+  const deleteFile = useCallback(id => _deleteFile(id), [_deleteFile]);
+
+  const getReadOnlyFieldsForItem = useCallback(item => {
+    /*
+      For FOLIO items users can only edit baseUrl and Active fields, so we need to disable the rest
+      For Local items all the fields are editable if the source file is not assigned to any Authority records.
+      But since backend doesn't send this information with the source files we allow to edit all fields and show a toast in case of save error
+    */
+    if (item.source === SOURCES.FOLIO) {
+      return [
+        authorityFilesColumns.NAME,
+        authorityFilesColumns.CODES,
+        authorityFilesColumns.START_NUMBER,
+      ];
+    }
+
+    return [];
+  }, []);
+
+  const isDataLoading = isSourceFilesLoading || isUpdatersLoading || isCentralTenantPermissionsLoading;
+
+  return {
+    canEdit: isUserHasEditPermission,
+    canCreate: isUserHasEditPermission,
+    canDelete: isUserHasEditPermission,
+    sourceFiles,
+    updaters,
+    isLoading: isDataLoading,
+    validate,
+    getReadOnlyFieldsForItem,
+    createFile,
+    updateFile,
+    deleteFile,
+  };
+};
+

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
@@ -5,7 +5,6 @@ import {
   useStripes,
   checkIfUserInMemberTenant,
 } from '@folio/stripes/core';
-
 import {
   useUserTenantPermissions,
   useAuthoritySourceFiles,

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
@@ -1,0 +1,249 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  useUsers,
+  useAuthoritySourceFiles,
+} from '@folio/stripes-authority-components';
+import { useStripes } from '@folio/stripes/core';
+
+import Harness from '../../../test/jest/helpers/harness';
+import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
+
+import { useManageAuthoritySourceFiles } from './useManageAuthoritySourceFiles';
+
+const sourceFiles = [{
+  id: 1,
+  name: 'Test file 1',
+  codes: ['a'],
+  hridManagement: {
+    startNumber: 1,
+  },
+  baseUrl: 'http://test-url-1',
+  selectable: true,
+  source: 'folio',
+  metadata: {
+    updatedByUserId: 'user-1',
+  },
+  _version: 1,
+}, {
+  id: 2,
+  name: 'Test file 2',
+  codes: ['b'],
+  hridManagement: {
+    startNumber: 2,
+  },
+  baseUrl: 'http://test-url-2',
+  selectable: true,
+  source: 'local',
+  metadata: {
+    updatedByUserId: 'user-2',
+  },
+  _version: 1,
+}];
+const mockCreateFile = jest.fn();
+const mockUpdateFile = jest.fn();
+const mockDeleteFile = jest.fn();
+const mockOnCreateSuccess = jest.fn();
+const mockOnUpdateSuccess = jest.fn();
+const mockOnDeleteSuccess = jest.fn();
+const mockonCreateFail = jest.fn();
+const mockOnUpdateFail = jest.fn();
+const mockOnDeleteFail = jest.fn();
+
+const defaultProps = {
+  onCreateSuccess: mockOnCreateSuccess,
+  onCreateFail: mockonCreateFail,
+  onUpdateSuccess: mockOnUpdateSuccess,
+  onUpdateFail: mockOnUpdateFail,
+  onDeleteSuccess: mockOnDeleteSuccess,
+  onDeleteFail: mockOnDeleteFail,
+};
+
+const renderUseManageAuthoritySourceFiles = (props = {}) => renderHook(() => useManageAuthoritySourceFiles({ ...defaultProps, ...props }), { wrapper: Harness });
+
+describe('Given useManageAuthoritySourceFiles', () => {
+  const centralTenantStripes = buildStripes({
+    okapi: {
+      tenant: 'consortia',
+    },
+  });
+  const singleTenantStripes = buildStripes({
+    okapi: {
+      tenant: 'diku',
+    },
+  });
+
+  beforeEach(() => {
+    useAuthoritySourceFiles.mockClear().mockReturnValue({
+      sourceFiles,
+      isLoading: false,
+      createFile: mockCreateFile,
+      updateFile: mockUpdateFile,
+      deleteFile: mockDeleteFile,
+    });
+    useStripes.mockClear().mockReturnValue(centralTenantStripes);
+    useUsers.mockClear().mockImplementation((userIds) => ({
+      users: userIds,
+      isLoading: false,
+    }));
+  });
+
+  describe('when user is in an multi-tenant environment', () => {
+    describe('when user does not have central tenant edit permissions', () => {
+      beforeEach(() => {
+        useStripes.mockClear().mockReturnValue({
+          ...centralTenantStripes,
+          hasPerm: () => false,
+        });
+      });
+
+      it('should return false for canEdit, canCreate, canDelete', () => {
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        expect(result.current.canCreate).toBeFalsy();
+        expect(result.current.canEdit).toBeFalsy();
+        expect(result.current.canDelete).toBeFalsy();
+      });
+    });
+
+    describe('when user has central tenant edit permissions', () => {
+      beforeEach(() => {
+        useStripes.mockClear().mockReturnValue({
+          ...centralTenantStripes,
+          hasPerm: () => true,
+        });
+      });
+
+      it('should return true for canEdit, canCreate, canDelete', () => {
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        expect(result.current.canCreate).toBeTruthy();
+        expect(result.current.canEdit).toBeTruthy();
+        expect(result.current.canDelete).toBeTruthy();
+      });
+    });
+  });
+
+  describe('when user is in an single-tenant environment', () => {
+    describe('when user does not have edit permissions', () => {
+      beforeEach(() => {
+        useStripes.mockClear().mockReturnValue({
+          ...singleTenantStripes,
+          hasInterface: () => false,
+          hasPerm: () => false,
+        });
+      });
+
+      it('should return false for canEdit, canCreate, canDelete', () => {
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        expect(result.current.canCreate).toBeFalsy();
+        expect(result.current.canEdit).toBeFalsy();
+        expect(result.current.canDelete).toBeFalsy();
+      });
+    });
+
+    describe('when user has edit permissions', () => {
+      beforeEach(() => {
+        useStripes.mockClear().mockReturnValue({
+          ...singleTenantStripes,
+          hasInterface: () => false,
+          hasPerm: () => true,
+        });
+      });
+
+      it('should return true for canEdit, canCreate, canDelete', () => {
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        expect(result.current.canCreate).toBeTruthy();
+        expect(result.current.canEdit).toBeTruthy();
+        expect(result.current.canDelete).toBeTruthy();
+      });
+    });
+  });
+
+  it('should return a list of updaters', () => {
+    const { result } = renderUseManageAuthoritySourceFiles();
+
+    expect(result.current.updaters).toEqual(['user-1', 'user-2']);
+  });
+
+  describe('when validating an item', () => {
+    describe('when there is an error', () => {
+      it('should return object with failed fields', () => {
+        const item = {}; // empty item will have validation errors. Doesn't matter which to test that validators return an error correctly
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        const failedProperties = Object.keys(result.current.validate(item, sourceFiles));
+
+        expect(failedProperties).not.toHaveLength(0);
+      });
+    });
+
+    describe('when there is no error', () => {
+      it('should return object with no fields', () => {
+        const item = {
+          codes: 'validcode',
+          name: 'New name',
+          baseUrl: 'http://new-url/',
+          startNumber: 1,
+        };
+        const { result } = renderUseManageAuthoritySourceFiles();
+
+        expect(result.current.validate(item, sourceFiles)).toEqual({});
+      });
+    });
+  });
+
+  describe('when calling createFile', () => {
+    it('should call mutator with correct data', () => {
+      const item = {
+        codes: 'validcode',
+        name: 'New name',
+        baseUrl: 'http://new-url/',
+        startNumber: 1,
+      };
+      const { result } = renderUseManageAuthoritySourceFiles();
+
+      result.current.createFile(item);
+
+      expect(mockCreateFile).toHaveBeenCalledWith({
+        code: 'validcode',
+        name: 'New name',
+        baseUrl: 'http://new-url/',
+        hridManagement: {
+          startNumber: 1,
+        },
+      });
+    });
+  });
+
+  describe('when calling updateFile', () => {
+    it('should call mutator with only changed fields and incremented version', () => {
+      const item = { ...sourceFiles[0] };
+      const { result } = renderUseManageAuthoritySourceFiles();
+
+      result.current.updateFile({
+        ...item,
+        name: 'Edited name',
+      });
+
+      expect(mockUpdateFile).toHaveBeenCalledWith({
+        id: 1,
+        name: 'Edited name',
+        _version: 2,
+      });
+    });
+  });
+
+  describe('when calling deleteFile', () => {
+    it('should call mutator file id', () => {
+      const item = { ...sourceFiles[0] };
+      const { result } = renderUseManageAuthoritySourceFiles();
+
+      result.current.deleteFile(item.id);
+
+      expect(mockDeleteFile).toHaveBeenCalledWith(item.id);
+    });
+  });
+});

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
@@ -201,7 +201,9 @@ describe('Given useManageAuthoritySourceFiles', () => {
         codes: 'validcode',
         name: 'New name',
         baseUrl: 'http://new-url/',
-        startNumber: 1,
+        hridManagement: {
+          startNumber: 1,
+        },
       };
       const { result } = renderUseManageAuthoritySourceFiles();
 

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
@@ -219,7 +219,7 @@ describe('Given useManageAuthoritySourceFiles', () => {
   });
 
   describe('when calling updateFile', () => {
-    it('should call mutator with only changed fields and incremented version', () => {
+    it('should call mutator with only changed fields', () => {
       const item = { ...sourceFiles[0] };
       const { result } = renderUseManageAuthoritySourceFiles();
 
@@ -231,7 +231,7 @@ describe('Given useManageAuthoritySourceFiles', () => {
       expect(mockUpdateFile).toHaveBeenCalledWith({
         id: 1,
         name: 'Edited name',
-        _version: 2,
+        _version: 1,
       });
     });
   });

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
@@ -186,7 +186,9 @@ describe('Given useManageAuthoritySourceFiles', () => {
           codes: 'validcode',
           name: 'New name',
           baseUrl: 'http://new-url/',
-          startNumber: 1,
+          hridManagement: {
+            startNumber: 1,
+          },
         };
         const { result } = renderUseManageAuthoritySourceFiles();
 

--- a/src/views/AuthorityView/AuthorityView.test.js
+++ b/src/views/AuthorityView/AuthorityView.test.js
@@ -2,13 +2,11 @@ import {
   fireEvent,
   render,
 } from '@folio/jest-config-stripes/testing-library/react';
-
 import {
   CommandList,
   defaultKeyboardShortcuts,
 } from '@folio/stripes/components';
 import { runAxeTest } from '@folio/stripes-testing';
-
 import { useUserTenantPermissions } from '@folio/stripes-authority-components';
 
 import Harness from '../../../test/jest/helpers/harness';
@@ -47,7 +45,6 @@ jest.mock('@folio/stripes/components', () => ({
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useUserTenantPermissions: jest.fn(),
-  useTenantKy: jest.fn(),
 }));
 
 const marcSource = {

--- a/test/jest/__mock__/stripesAuthorityComponents.mock.js
+++ b/test/jest/__mock__/stripesAuthorityComponents.mock.js
@@ -4,4 +4,15 @@ jest.mock('@folio/stripes-authority-components', () => ({
     userPermissions: [],
     isFetching: false,
   }),
+  useUsers: jest.fn().mockReturnValue({
+    users: [],
+    isLoading: false,
+  }),
+  useAuthoritySourceFiles: jest.fn().mockReturnValue({
+    sourceFiles: [],
+    isLoading: false,
+    createFile: jest.fn(),
+    updateFile: jest.fn(),
+    deleteFile: jest.fn(),
+  }),
 }));

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -115,6 +115,7 @@ jest.mock('@folio/stripes/core', () => {
     AppContextMenu,
     useOkapiKy,
     useNamespace,
+    useStripes: jest.fn().mockReturnValue(STRIPES),
   };
 }, { virtual: true });
 

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -95,6 +95,7 @@
   "settings.manageAuthoritySourceFiles.create.success": "The authority file <b>{name}</b> has been successfully <b>created</b>.",
   "settings.manageAuthoritySourceFiles.update.success": "The authority file <b>{name}</b> has been successfully <b>updated</b>.",
   "settings.manageAuthoritySourceFiles.update.fail.fileAssigned": "Changes to <b>{name}</b> cannot be saved. Existing authority records are already assigned to this authority file.",
+  "settings.manageAuthoritySourceFiles.update.fail.optimisticLocking": "Changes to <b>{name}</b> cannot be saved because it is <b>not</b> the most recent version.",
   "settings.manageAuthoritySourceFiles.delete.success": "The authority file <b>{name}</b> has been successfully <b>deleted</b>.",
 
   "error.defaultSaveError": "Error on saving data"

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -92,5 +92,10 @@
   "settings.manageAuthoritySourceFiles.error.codes.unique": "Error saving data. Prefix must be unique.",
   "settings.manageAuthoritySourceFiles.error.codes.empty": "Error saving data. Prefix is required.",
   "settings.manageAuthoritySourceFiles.error.codes.length": "Error saving data. Prefix cannot be more than {maxlength} characters.",
-  "settings.manageAuthoritySourceFiles.create.success": "The authority file (name) has been successfully created."
+  "settings.manageAuthoritySourceFiles.create.success": "The authority file <b>{name}</b> has been successfully <b>created</b>.",
+  "settings.manageAuthoritySourceFiles.update.success": "The authority file <b>{name}</b> has been successfully <b>updated</b>.",
+  "settings.manageAuthoritySourceFiles.update.fail.fileAssigned": "Changes to <b>{name}</b> cannot be saved. Existing authority records are already assigned to this authority file.",
+  "settings.manageAuthoritySourceFiles.delete.success": "The authority file <b>{name}</b> has been successfully <b>deleted</b>.",
+
+  "error.defaultSaveError": "Error on saving data"
 }


### PR DESCRIPTION
## Description
Updated imlementation of Manage Authority Source Files settings:
- now using `<EditableList>` instead of `<ControlledVocab>` because `<ControlledVocab>` uses `POST` method for updating records, but our API provides only `PATCH`
- separate presentation and logic into a view component and a hook
- updated tests

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/19309423/4a35cf8a-df78-4abb-abe9-4b12a364bce7



## Issues
[UIMARCAUTH-359](https://issues.folio.org/browse/UIMARCAUTH-359)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1435
https://github.com/folio-org/stripes-authority-components/pull/137