### PR TITLE
UIMARCAUTH-369: Add Create a new MARC authority record keyboard shortcut.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [UIMARCAUTH-337](https://issues.folio.org/browse/UIMARCAUTH-337) Add `Manage authority files` settings.
 - [UIMARCAUTH-360](https://issues.folio.org/browse/UIMARCAUTH-360) Implement creation of Authority Source Files.
 - [UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-374) Use `onSave` prop for quickMARC to handle saving records separately.
+- [UIMARCAUTH-369](https://issues.folio.org/browse/UIMARCAUTH-369) Add Create a new MARC authority record keyboard shortcut.
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,6 +1,9 @@
 import { FormattedMessage } from 'react-intl';
 
+import { defaultKeyboardShortcuts } from '@folio/stripes/components';
+
 const commands = [
+  defaultKeyboardShortcuts.find(shortcut => shortcut.name === 'new'),
   {
     name: 'edit',
     label: (<FormattedMessage id="ui-marc-authorities.shortcut.editRecord" />),

--- a/src/constants/createAuthorityRoute.js
+++ b/src/constants/createAuthorityRoute.js
@@ -1,0 +1,1 @@
+export const createAuthorityRoute = '/marc-authorities/quick-marc/create-authority';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,3 +2,4 @@ export * from './sortableSearchResultListColumns';
 export * from './sortOrders';
 export * from './queryKeys';
 export * from './exportAuthorityJobProfileId';
+export * from './createAuthorityRoute';

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -32,6 +32,8 @@ import {
   TextLink,
   Checkbox,
   PaneMenu,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import {
   PersistedPaneset,
@@ -44,6 +46,7 @@ import {
   useNamespace,
   CalloutContext,
   IfPermission,
+  useStripes,
 } from '@folio/stripes/core';
 import { buildSearch } from '@folio/stripes-acq-components';
 import {
@@ -115,6 +118,7 @@ const AuthoritiesSearch = ({
   hasNextPage,
   hasPrevPage,
 }) => {
+  const stripes = useStripes();
   const intl = useIntl();
   const [, getNamespace] = useNamespace();
   const match = useRouteMatch();
@@ -160,6 +164,21 @@ const AuthoritiesSearch = ({
 
   const selectedRowsIds = useMemo(() => (Object.keys(selectedRows)), [selectedRows]);
   const selectedRowsCount = useMemo(() => (Object.keys(selectedRows).length), [selectedRows]);
+
+  const openCreateAuthorityScreen = useCallback(() => {
+    history.push('/marc-authorities/quick-marc/create-authority');
+  }, []);
+
+  const shortcuts = [
+    {
+      name: 'new',
+      handler: () => {
+        if (stripes.hasPerm('ui-marc-authorities.authority-record.create')) {
+          openCreateAuthorityScreen();
+        }
+      },
+    },
+  ];
 
   const rowExistsInSelectedRows = row => {
     return selectedRowsIds.includes(row.id);
@@ -493,7 +512,7 @@ const AuthoritiesSearch = ({
             <Button
               buttonStyle="dropdownItem"
               id="dropdown-clickable-create-authority"
-              to="/marc-authorities/quick-marc/create-authority"
+              onClick={openCreateAuthorityScreen}
             >
               <Icon icon="plus-sign">
                 <FormattedMessage id="ui-marc-authorities.actions.create" />
@@ -540,6 +559,7 @@ const AuthoritiesSearch = ({
     toggleColumn,
     visibleColumns,
     onSelectReport,
+    openCreateAuthorityScreen,
   ]);
 
   const renderPaneSub = () => (
@@ -592,74 +612,80 @@ const AuthoritiesSearch = ({
   };
 
   return (
-    <PersistedPaneset
-      appId="@folio/marc-authorities"
-      id="marc-authorities-paneset"
-      data-testid="marc-authorities-paneset"
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
     >
-      <AuthoritiesSearchPane
-        isFilterPaneVisible={isFilterPaneVisible}
-        toggleFilterPane={toggleFilterPane}
-        isLoading={isLoading}
-        onSubmitSearch={onSubmitSearch}
-        resetSelectedRows={resetSelectedRows}
-        query={query}
-        firstPageQuery={firstPageQuery}
-        hasAdvancedSearch
-        hasQueryOption={false}
-        hasMatchSelection
-      />
-      <Pane
-        id="authority-search-results-pane"
-        appIcon={<AppIcon app="marc-authorities" />}
-        defaultWidth="fill"
-        paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
-        paneSub={renderPaneSub()}
-        firstMenu={renderResultsFirstMenu()}
-        actionMenu={renderActionMenu}
-        padContent={false}
-        noOverflow
+      <PersistedPaneset
+        appId="@folio/marc-authorities"
+        id="marc-authorities-paneset"
+        data-testid="marc-authorities-paneset"
       >
-        <SearchResultsList
-          authorities={authorities}
-          columnMapping={columnMapping}
-          columnWidths={{
-            [searchResultListColumns.SELECT]: '30px',
-            [searchResultListColumns.NUMBER_OF_TITLES]: '140px',
-            [searchResultListColumns.AUTH_REF_TYPE]: '190px',
-            [searchResultListColumns.HEADING_REF]: '350px',
-            [searchResultListColumns.HEADING_TYPE]: '170px',
-            [searchResultListColumns.AUTHORITY_SOURCE]: '250px',
-          }}
-          formatter={formatter}
-          hasNextPage={hasNextPage}
-          hasPrevPage={hasPrevPage}
-          totalResults={totalRecords}
-          pageSize={pageSize}
-          onNeedMoreData={handleLoadMore}
-          loading={isLoading}
-          loaded={isLoaded}
-          visibleColumns={visibleColumns}
-          sortedColumn={sortedColumn}
-          sortOrder={sortOrder}
-          onHeaderClick={onHeaderClick}
+        <AuthoritiesSearchPane
           isFilterPaneVisible={isFilterPaneVisible}
           toggleFilterPane={toggleFilterPane}
-          hasFilters={!!filters.length}
-          query={searchQuery}
-          hidePageIndices={hidePageIndices}
-          renderHeadingRef={renderHeadingRef}
-          nonInteractiveHeaders={NON_INTERACTIVE_HEADERS}
+          isLoading={isLoading}
+          onSubmitSearch={onSubmitSearch}
+          resetSelectedRows={resetSelectedRows}
+          query={query}
+          firstPageQuery={firstPageQuery}
+          hasAdvancedSearch
+          hasQueryOption={false}
+          hasMatchSelection
         />
-      </Pane>
-      {children}
-      <ReportsModal
-        open={reportsModalOpen}
-        reportType={selectedReport.current}
-        onClose={() => setReportsModalOpen(false)}
-        onSubmit={handleReportsSubmit}
-      />
-    </PersistedPaneset>
+        <Pane
+          id="authority-search-results-pane"
+          appIcon={<AppIcon app="marc-authorities" />}
+          defaultWidth="fill"
+          paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
+          paneSub={renderPaneSub()}
+          firstMenu={renderResultsFirstMenu()}
+          actionMenu={renderActionMenu}
+          padContent={false}
+          noOverflow
+        >
+          <SearchResultsList
+            authorities={authorities}
+            columnMapping={columnMapping}
+            columnWidths={{
+              [searchResultListColumns.SELECT]: '30px',
+              [searchResultListColumns.NUMBER_OF_TITLES]: '140px',
+              [searchResultListColumns.AUTH_REF_TYPE]: '190px',
+              [searchResultListColumns.HEADING_REF]: '350px',
+              [searchResultListColumns.HEADING_TYPE]: '170px',
+              [searchResultListColumns.AUTHORITY_SOURCE]: '250px',
+            }}
+            formatter={formatter}
+            hasNextPage={hasNextPage}
+            hasPrevPage={hasPrevPage}
+            totalResults={totalRecords}
+            pageSize={pageSize}
+            onNeedMoreData={handleLoadMore}
+            loading={isLoading}
+            loaded={isLoaded}
+            visibleColumns={visibleColumns}
+            sortedColumn={sortedColumn}
+            sortOrder={sortOrder}
+            onHeaderClick={onHeaderClick}
+            isFilterPaneVisible={isFilterPaneVisible}
+            toggleFilterPane={toggleFilterPane}
+            hasFilters={!!filters.length}
+            query={searchQuery}
+            hidePageIndices={hidePageIndices}
+            renderHeadingRef={renderHeadingRef}
+            nonInteractiveHeaders={NON_INTERACTIVE_HEADERS}
+          />
+        </Pane>
+        {children}
+        <ReportsModal
+          open={reportsModalOpen}
+          reportType={selectedReport.current}
+          onClose={() => setReportsModalOpen(false)}
+          onSubmit={handleReportsSubmit}
+        />
+      </PersistedPaneset>
+    </HasCommand>
   );
 };
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -72,6 +72,7 @@ import {
 } from '../../queries';
 import { useReportGenerator } from '../../hooks';
 import {
+  createAuthorityRoute,
   sortableSearchResultListColumns,
   sortOrders,
 } from '../../constants';
@@ -165,16 +166,12 @@ const AuthoritiesSearch = ({
   const selectedRowsIds = useMemo(() => (Object.keys(selectedRows)), [selectedRows]);
   const selectedRowsCount = useMemo(() => (Object.keys(selectedRows).length), [selectedRows]);
 
-  const openCreateAuthorityScreen = useCallback(() => {
-    history.push('/marc-authorities/quick-marc/create-authority');
-  }, []);
-
   const shortcuts = [
     {
       name: 'new',
       handler: () => {
         if (stripes.hasPerm('ui-marc-authorities.authority-record.create')) {
-          openCreateAuthorityScreen();
+          history.push(createAuthorityRoute);
         }
       },
     },
@@ -512,7 +509,7 @@ const AuthoritiesSearch = ({
             <Button
               buttonStyle="dropdownItem"
               id="dropdown-clickable-create-authority"
-              onClick={openCreateAuthorityScreen}
+              to={createAuthorityRoute}
             >
               <Icon icon="plus-sign">
                 <FormattedMessage id="ui-marc-authorities.actions.create" />
@@ -559,7 +556,6 @@ const AuthoritiesSearch = ({
     toggleColumn,
     visibleColumns,
     onSelectReport,
-    openCreateAuthorityScreen,
   ]);
 
   const renderPaneSub = () => (

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -2,7 +2,9 @@ import {
   waitFor,
   render,
   fireEvent,
+  act,
 } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { runAxeTest } from '@folio/stripes-testing';
 import { searchResultListColumns } from '@folio/stripes-authority-components';
@@ -491,5 +493,15 @@ describe('Given AuthoritiesSearch', () => {
     expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeVisible();
     expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authoritySource' })).toBeVisible();
     expect(getByRole('columnheader', { name: 'ui-marc-authorities.search-results-list.numberOfTitles' })).toBeVisible();
+  });
+
+  describe('when the "+ New" action is pressed', () => {
+    it('should open create authority record screen', async () => {
+      const { getByText } = renderAuthoritiesSearch();
+
+      await act(() => userEvent.click(getByText('ui-marc-authorities.actions.create')));
+
+      expect(mockHistoryPush).toHaveBeenCalledWith('/marc-authorities/quick-marc/create-authority');
+    });
   });
 });

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -2,9 +2,7 @@ import {
   waitFor,
   render,
   fireEvent,
-  act,
 } from '@folio/jest-config-stripes/testing-library/react';
-import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { runAxeTest } from '@folio/stripes-testing';
 import { searchResultListColumns } from '@folio/stripes-authority-components';
@@ -493,15 +491,5 @@ describe('Given AuthoritiesSearch', () => {
     expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeVisible();
     expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authoritySource' })).toBeVisible();
     expect(getByRole('columnheader', { name: 'ui-marc-authorities.search-results-list.numberOfTitles' })).toBeVisible();
-  });
-
-  describe('when the "+ New" action is pressed', () => {
-    it('should open create authority record screen', async () => {
-      const { getByText } = renderAuthoritiesSearch();
-
-      await act(() => userEvent.click(getByText('ui-marc-authorities.actions.create')));
-
-      expect(mockHistoryPush).toHaveBeenCalledWith('/marc-authorities/quick-marc/create-authority');
-    });
   });
 });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
- MARC authority app - should have the `alt + n` keyboard shortcut for creating a new MARC authority record;
- MARC authority keyboard shortcut modal list - display the new shortcut key as the first row above the Edit a record shortcut key.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->



## Issues
[UIMARCAUTH-369](https://issues.folio.org/browse/UIMARCAUTH-369)

## Screenshots


![image](https://github.com/folio-org/ui-marc-authorities/assets/77053927/8f54866c-c558-4e91-b5c2-fb143cf130b6)


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
