### PR TITLE
UIMARCAUTH-361: DELETE | Create new settings options for configuring authority files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [UIMARCAUTH-369](https://issues.folio.org/browse/UIMARCAUTH-369) Add Create a new MARC authority record keyboard shortcut.
 - [UIMARCAUTH-374](https://issues.folio.org/browse/UIMARCAUTH-382) Add the same permissions that are listed in `quickMARC: Create a new MARC authority record` to `Create new MARC authority record`.
 - [UIMARCAUTH-359](https://issues.folio.org/browse/UIMARCAUTH-359) EDIT | Create new settings options for configuring authority files
+- [UIMARCAUTH-361](https://issues.folio.org/browse/UIMARCAUTH-361) DELETE | Create new settings options for configuring authority files
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/jest-config-stripes": "^2.0.0",
     "@folio/stripes": "^9.0.0",
-    "@folio/stripes-authority-components": "^3.0.0",
+    "@folio/stripes-authority-components": "^4.0.0",
     "@folio/stripes-marc-components": "^1.0.0",
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-connect": "^9.0.0",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
-    "@folio/stripes-authority-components": "^3.0.0",
+    "@folio/stripes-authority-components": "^4.0.0",
     "@folio/stripes-marc-components": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/ManageAuthoritySourceFiles.js
@@ -57,7 +57,7 @@ const ManageAuthoritySourceFiles = () => {
       : 'ui-marc-authorities.error.defaultSaveError';
 
     callout.sendCallout({
-      message: <FormattedMessage id={translationId} values={{ name }} />,
+      message: intl.formatMessage({ id: translationId }, { name }),
       type: 'error',
     });
   };
@@ -66,6 +66,7 @@ const ManageAuthoritySourceFiles = () => {
   const onUpdateSuccess = ({ name }) => showSuccessMessage(ACTION_TYPES.UPDATE, name);
   const onDeleteSuccess = ({ name }) => showSuccessMessage(ACTION_TYPES.DELETE, name);
   const onUpdateFail = ({ name, reason }) => showErrorMessage(ACTION_TYPES.UPDATE, name, reason);
+  const onDeleteFail = ({ name, reason }) => showErrorMessage(ACTION_TYPES.DELETE, name, reason);
 
   const {
     sourceFiles,
@@ -84,6 +85,7 @@ const ManageAuthoritySourceFiles = () => {
     onUpdateSuccess,
     onDeleteSuccess,
     onUpdateFail,
+    onDeleteFail,
   });
 
   const paneTitle = intl.formatMessage({ id: 'ui-marc-authorities.settings.manageAuthoritySourceFiles.pane.title' });
@@ -222,6 +224,9 @@ const ManageAuthoritySourceFiles = () => {
           fieldComponents={getFieldComponents(selectableFieldLabel, intl)}
           columnWidths={columnWidths}
           canCreate={canCreate}
+          withDeleteConfirmation
+          confirmationHeading={fileId => sourceFiles.find(file => file.id === fileId)?.name}
+          confirmationMessage={<FormattedMessage id="ui-marc-authorities.settings.manageAuthoritySourceFiles.confirmationModal.message" />}
         />
       </Pane>
     </TitleManager>

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -93,6 +93,10 @@ jest.mock('@folio/stripes/core', () => {
 
   const useNamespace = () => ['@folio/marc-authorities', jest.fn()];
 
+  const useCallout = jest.fn().mockReturnValue({
+    sendCallout: jest.fn(),
+  });
+
   // eslint-disable-next-line react/prop-types
   const withStripes = Component => function ({ stripes, ...rest }) {
     const fakeStripes = stripes || STRIPES;
@@ -115,6 +119,7 @@ jest.mock('@folio/stripes/core', () => {
     AppContextMenu,
     useOkapiKy,
     useNamespace,
+    useCallout,
     useStripes: jest.fn().mockReturnValue(STRIPES),
   };
 }, { virtual: true });

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -96,7 +96,11 @@
   "settings.manageAuthoritySourceFiles.update.success": "The authority file <b>{name}</b> has been successfully <b>updated</b>.",
   "settings.manageAuthoritySourceFiles.update.fail.fileAssigned": "Changes to <b>{name}</b> cannot be saved. Existing authority records are already assigned to this authority file.",
   "settings.manageAuthoritySourceFiles.update.fail.optimisticLocking": "Changes to <b>{name}</b> cannot be saved because it is <b>not</b> the most recent version.",
-  "settings.manageAuthoritySourceFiles.delete.success": "The authority file <b>{name}</b> has been successfully <b>deleted</b>.",
+  "settings.manageAuthoritySourceFiles.delete.success": "Authority file <b>{name}</b> has been <b>deleted</b>.",
+  "settings.manageAuthoritySourceFiles.delete.fail.fileAssigned": "<b>{name}</b> cannot be deleted. Existing authority records are already assigned to this authority file.",
+  "settings.manageAuthoritySourceFiles.confirmationModal.message": "Are you sure you want to delete this authority file? After deletion, new records will no longer be able to be assigned to this authority file.",
+  "settings.manageAuthoritySourceFiles.confirmationModal.cancel": "No, do not delete",
+  "settings.manageAuthoritySourceFiles.confirmationModal.confirm": "Yes, delete",
 
   "error.defaultSaveError": "Error on saving data"
 }


### PR DESCRIPTION
## Description
Handle deletion of Authority Source files

## Screenshots
https://github.com/folio-org/ui-marc-authorities/assets/19309423/84e25775-cc9c-4476-9bd4-994a06d4f40e

## Issues
[UIMARCAUTH-361](https://folio-org.atlassian.net/browse/UIMARCAUTH-361)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1440