### PR TITLE
UIMARCAUTH-371 Show default html title when search query is empty (follow-up)

### DIFF
--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -92,8 +92,16 @@ const BrowseRoute = ({ children }) => {
     });
   }, [authorities]);
 
+  const pageTitle = useMemo(() => {
+    if (searchQuery) {
+      return intl.formatMessage({ id: 'ui-marc-authorities.documentTitle.browse' }, { query: searchQuery });
+    }
+
+    return intl.formatMessage({ id: 'ui-marc-authorities.meta.title' });
+  }, [searchQuery, intl]);
+
   return (
-    <TitleManager page={intl.formatMessage({ id: 'ui-marc-authorities.documentTitle.browse' }, { query: searchQuery })}>
+    <TitleManager page={pageTitle}>
       <AuthoritiesSearch
         authorities={formattedAuthoritiesForView}
         hasNextPage={hasNextPage}

--- a/src/routes/BrowseRoute/BrowseRoute.test.js
+++ b/src/routes/BrowseRoute/BrowseRoute.test.js
@@ -23,8 +23,8 @@ jest.mock('../../views', () => ({
   )),
 }));
 
-const renderBrowseRoute = () => render(
-  <Harness>
+const renderBrowseRoute = (authoritiesCtxValue) => render(
+  <Harness authoritiesCtxValue={authoritiesCtxValue}>
     <BrowseRoute>
       children content
     </BrowseRoute>
@@ -61,6 +61,22 @@ describe('Given BrowseRoute', () => {
     const { getByText } = renderBrowseRoute();
 
     expect(getByText('children content')).toBeDefined();
+  });
+
+  describe('when search query is empty', () => {
+    it('should show default document.title', () => {
+      renderBrowseRoute();
+
+      expect(document.title).toEqual('ui-marc-authorities.meta.title - FOLIO');
+    });
+  });
+
+  describe('when search query is not empty', () => {
+    it('should show default document.title', () => {
+      renderBrowseRoute({ searchQuery: 'test' });
+
+      expect(document.title).toEqual('ui-marc-authorities.documentTitle.browse - FOLIO');
+    });
   });
 
   describe('when a user clicks on the pagination button', () => {

--- a/src/routes/SearchRoute/SearchRoute.js
+++ b/src/routes/SearchRoute/SearchRoute.js
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -100,8 +100,16 @@ const SearchRoute = ({ children }) => {
     setOffset(_offset);
   };
 
+  const pageTitle = useMemo(() => {
+    if (searchQuery) {
+      return intl.formatMessage({ id: 'ui-marc-authorities.documentTitle.search' }, { query: searchQuery });
+    }
+
+    return intl.formatMessage({ id: 'ui-marc-authorities.meta.title' });
+  }, [searchQuery, intl]);
+
   return (
-    <TitleManager page={intl.formatMessage({ id: 'ui-marc-authorities.documentTitle.search' }, { query: searchQuery })}>
+    <TitleManager page={pageTitle}>
       <AuthoritiesSearch
         authorities={authorities}
         isLoading={isLoading}

--- a/src/routes/SearchRoute/SearchRoute.test.js
+++ b/src/routes/SearchRoute/SearchRoute.test.js
@@ -28,8 +28,8 @@ jest.mock('../../views', () => ({
   ),
 }));
 
-const renderSearchRoute = () => render(
-  <Harness>
+const renderSearchRoute = (authoritiesCtxValue) => render(
+  <Harness authoritiesCtxValue={authoritiesCtxValue}>
     <SearchRoute>
       children content
     </SearchRoute>
@@ -53,6 +53,22 @@ describe('Given SearchRoute', () => {
     const { getByText } = renderSearchRoute();
 
     expect(getByText('children content')).toBeDefined();
+  });
+
+  describe('when search query is empty', () => {
+    it('should show default document.title', () => {
+      renderSearchRoute();
+
+      expect(document.title).toEqual('ui-marc-authorities.meta.title - FOLIO');
+    });
+  });
+
+  describe('when search query is not empty', () => {
+    it('should show default document.title', () => {
+      renderSearchRoute({ searchQuery: 'test', filters: {} });
+
+      expect(document.title).toEqual('ui-marc-authorities.documentTitle.search - FOLIO');
+    });
   });
 
   describe('when click on search button', () => {


### PR DESCRIPTION
## Description
Show default html title when search query is empty

## Screenshots
![image](https://github.com/folio-org/ui-marc-authorities/assets/19309423/65ae3e89-de41-4aa9-8eea-4b58175ffd50)


## Issues
[UIMARCAUTH-371](https://folio-org.atlassian.net/browse/UIMARCAUTH-371)