### PR TITLE
UIMARCAUTH-392 When updating Authority Source files, send `code` instead of `codes` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [UIMARCAUTH-370](https://issues.folio.org/browse/UIMARCAUTH-370) Add base url validation for authority file settings.
 - [UIMARCAUTH-371](https://issues.folio.org/browse/UIMARCAUTH-371) MARC Authority app > Search and Browse Results > Update HTML page title with search term entered.
 - [UIMARCAUTH-372](https://issues.folio.org/browse/UIMARCAUTH-372) MARC authority app: HTML Page title should display the Detail record title when third pane displays.
+- [UIMARCAUTH-392](https://issues.folio.org/browse/UIMARCAUTH-392) When updating Authority Source files, send `code` instead of `codes` property.
 
 ## [4.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.1) (2023-11-29)
 

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
@@ -122,6 +122,10 @@ export const useManageAuthoritySourceFiles = ({
       return { ...acc, [field]: file[field] || ITEM_TEMPLATE[field] }; // need default empty value because for some reason when clearing a field, final-form removes this property from item completely
     }, {});
 
+    changedFields.code = changedFields[authorityFilesColumns.CODES];
+
+    delete changedFields[authorityFilesColumns.CODES];
+
     return {
       id: file.id,
       _version: file._version,

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.test.js
@@ -235,12 +235,14 @@ describe('Given useManageAuthoritySourceFiles', () => {
         ...item,
         name: 'Edited name',
         baseUrl: 'http://test-url-1',
+        codes: 'newcode',
       });
 
       expect(mockUpdateFile).toHaveBeenCalledWith({
         id: 1,
         name: 'Edited name',
         baseUrl: 'http://test-url-1',
+        code: 'newcode',
         _version: 1,
       });
     });


### PR DESCRIPTION
## Description
PATCH endpoint changed to use `code` instead of `codes` property

## Issues
[UIMARCAUTH-392](https://folio-org.atlassian.net/browse/UIMARCAUTH-392)