### PR TITLE
UIMARCAUTH-391 Source Files settings - Send empty string instead of null as empty baseUrl value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [UIMARCAUTH-371](https://issues.folio.org/browse/UIMARCAUTH-371) MARC Authority app > Search and Browse Results > Update HTML page title with search term entered.
 - [UIMARCAUTH-372](https://issues.folio.org/browse/UIMARCAUTH-372) MARC authority app: HTML Page title should display the Detail record title when third pane displays.
 - [UIMARCAUTH-392](https://issues.folio.org/browse/UIMARCAUTH-392) When updating Authority Source files, send `code` instead of `codes` property.
+- [UIMARCAUTH-391](https://issues.folio.org/browse/UIMARCAUTH-391) Source Files settings - Send empty string instead of null as empty baseUrl value.
 
 ## [4.0.2](https://github.com/folio-org/ui-marc-authorities/tree/v4.0.2) (2024-02-28)
 

--- a/src/settings/ManageAuthoritySourceFiles/constants.js
+++ b/src/settings/ManageAuthoritySourceFiles/constants.js
@@ -22,7 +22,7 @@ export const ITEM_TEMPLATE = {
   hridManagement: {
     startNumber: '',
   },
-  [authorityFilesColumns.BASE_URL]: null,
+  [authorityFilesColumns.BASE_URL]: '',
   [authorityFilesColumns.SOURCE]: SOURCES.LOCAL,
   [authorityFilesColumns.SELECTABLE]: false,
 };


### PR DESCRIPTION
## Description
BE updated the endpoint to accept `''` as empty baseUrl value, so we need to update our defaults as well

## Issues
[UIMARCAUTH-391](https://folio-org.atlassian.net/browse/UIMARCAUTH-391)