### PR TITLE
UIMARCAUTH-396 Add quickMARC shortcuts to modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.1.0] (IN PROGRESS)
 
 - [UIMARCAUTH-408](https://issues.folio.org/browse/UIMARCAUTH-408) Import `useUserTenantPermissions` from `@folio/stripes/core`.
+- [UIMARCAUTH-396](https://issues.folio.org/browse/UIMARCAUTH-396) Add quickMARC shortcuts to modal.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -24,6 +24,16 @@ const commands = [
     label: (<FormattedMessage id="ui-marc-authorities.shortcut.openShortcutModal" />),
     shortcut: 'mod+alt+k',
   },
+  {
+    label: <FormattedMessage id="ui-marc-authorities.shortcut.nextSubfield" />,
+    name: 'NEXT_SUBFIELD',
+    shortcut: 'Ctrl + ]',
+  },
+  {
+    label: <FormattedMessage id="ui-marc-authorities.shortcut.prevSubfield" />,
+    name: 'PREV_SUBFIELD',
+    shortcut: 'Ctrl + [',
+  },
 ];
 
 export default commands;

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -47,6 +47,8 @@
   "shortcut.cut": "Cut",
   "shortcut.paste": "Paste",
   "shortcut.find": "Find",
+  "shortcut.nextSubfield": "quickMARC only: Move to the next subfield in a text box",
+  "shortcut.prevSubfield": "quickMARC only: Move to the previous subfield in a text box",
 
   "delete.buttonLabel": "Delete",
   "delete.label": "Confirm deletion of authority record",


### PR DESCRIPTION
## Description
Addd quickMARC shortcuts to modal

## Screenshots
![image](https://github.com/folio-org/ui-marc-authorities/assets/19309423/18cb63da-d6fa-4385-87f5-c598ca9e8c34)



## Issues
[UIMARCAUTH-396](https://folio-org.atlassian.net/browse/UIMARCAUTH-396)