### PR TITLE
UIMARCAUTH-415: Pass the record search error to the `SearchResultsList` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UIMARCAUTH-396](https://issues.folio.org/browse/UIMARCAUTH-396) Add quickMARC shortcuts to modal.
 - [UIMARCAUTH-375](https://issues.folio.org/browse/UIMARCAUTH-375) Quick export from authority detail view.
 - [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-410) Open manage authority file settings in full screen view.
+- [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-415) Pass the record search error to the `SearchResultsList` component.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/src/routes/BrowseRoute/BrowseRoute.js
+++ b/src/routes/BrowseRoute/BrowseRoute.js
@@ -50,6 +50,7 @@ const BrowseRoute = ({ children }) => {
     query,
     firstPageQuery,
     totalRecords,
+    error,
   } = useAuthoritiesBrowse({
     filters,
     searchQuery,
@@ -92,6 +93,7 @@ const BrowseRoute = ({ children }) => {
   return (
     <AuthoritiesSearch
       authorities={formattedAuthoritiesForView}
+      error={error}
       hasNextPage={hasNextPage}
       hasPrevPage={hasPrevPage}
       totalRecords={totalRecords}

--- a/src/routes/SearchRoute/SearchRoute.js
+++ b/src/routes/SearchRoute/SearchRoute.js
@@ -66,6 +66,7 @@ const SearchRoute = ({ children }) => {
     isLoaded,
     totalRecords,
     query,
+    error,
   } = useAuthorities({
     searchQuery,
     searchIndex,
@@ -100,6 +101,7 @@ const SearchRoute = ({ children }) => {
   return (
     <AuthoritiesSearch
       authorities={authorities}
+      error={error}
       isLoading={isLoading}
       isLoaded={isLoaded}
       totalRecords={totalRecords}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -87,6 +87,7 @@ const propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
+  error: PropTypes.object,
   firstPageQuery: PropTypes.string.isRequired,
   handleLoadMore: PropTypes.func.isRequired,
   hasNextPage: PropTypes.bool,
@@ -103,6 +104,7 @@ const propTypes = {
 
 const AuthoritiesSearch = ({
   children,
+  error,
   onHeaderClick,
   handleLoadMore,
   authorities,
@@ -628,6 +630,7 @@ const AuthoritiesSearch = ({
               [searchResultListColumns.HEADING_TYPE]: '170px',
               [searchResultListColumns.AUTHORITY_SOURCE]: '250px',
             }}
+            error={error}
             formatter={formatter}
             hasNextPage={hasNextPage}
             hasPrevPage={hasPrevPage}
@@ -663,6 +666,7 @@ const AuthoritiesSearch = ({
 
 AuthoritiesSearch.propTypes = propTypes;
 AuthoritiesSearch.defaultProps = {
+  error: null,
   hidePageIndices: false,
   query: '',
   hasNextPage: null,


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Pass the record search error to the `SearchResultsList` component.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIMARCAUTH-415](https://folio-org.atlassian.net/browse/UIMARCAUTH-415)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
