### PR TITLE
UIMARCAUTH-411 Send requests for Source Files Settings with current tenant id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - [UIMARCAUTH-396](https://issues.folio.org/browse/UIMARCAUTH-396) Add quickMARC shortcuts to modal.
 - [UIMARCAUTH-375](https://issues.folio.org/browse/UIMARCAUTH-375) Quick export from authority detail view.
 - [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-410) Open manage authority file settings in full screen view.
-- [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-415) Pass the record search error to the `SearchResultsList` component.
+- [UIMARCAUTH-415](https://issues.folio.org/browse/UIMARCAUTH-415) Pass the record search error to the `SearchResultsList` component.
+- [UIMARCAUTH-411](https://issues.folio.org/browse/UIMARCAUTH-411) Send requests for Source Files Settings with current tenant id.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
+++ b/src/settings/ManageAuthoritySourceFiles/useManageAuthoritySourceFiles.js
@@ -39,7 +39,6 @@ export const useManageAuthoritySourceFiles = ({
     updateFile: _updateFile,
     deleteFile: _deleteFile,
   } = useAuthoritySourceFiles({
-    tenantId: centralTenantId || stripes.okapi.tenant,
     onCreateSuccess,
     onUpdateSuccess,
     onDeleteSuccess,
@@ -64,7 +63,7 @@ export const useManageAuthoritySourceFiles = ({
   } = useUserTenantPermissions({
     tenantId: centralTenantId,
   }, {
-    enabled: checkIfUserInMemberTenant(stripes),
+    enabled: checkIfUserInMemberTenant(stripes) && Boolean(centralTenantId),
   });
 
   const isUserHasEditPermission = checkIfUserInMemberTenant(stripes)


### PR DESCRIPTION
## Description
Requests for Authority Source files should be made with current tenant id, because having only member tenant permissions is not enough to view the settings

## Issues
[UIMARCAUTH-411](https://folio-org.atlassian.net/browse/UIMARCAUTH-411)