### PR TITLE
UIMARCAUTH-404: Focus on record title after closing record details view, on search field after canceling record creation, on close record details view icon after closing quick-marc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-410) Open manage authority file settings in full screen view.
 - [UIMARCAUTH-415](https://issues.folio.org/browse/UIMARCAUTH-415) Pass the record search error to the `SearchResultsList` component.
 - [UIMARCAUTH-411](https://issues.folio.org/browse/UIMARCAUTH-411) Send requests for Source Files Settings with current tenant id.
+- [UIMARCAUTH-404](https://issues.folio.org/browse/UIMARCAUTH-404) Focus on record title after closing record details view.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [UIMARCAUTH-410](https://issues.folio.org/browse/UIMARCAUTH-410) Open manage authority file settings in full screen view.
 - [UIMARCAUTH-415](https://issues.folio.org/browse/UIMARCAUTH-415) Pass the record search error to the `SearchResultsList` component.
 - [UIMARCAUTH-411](https://issues.folio.org/browse/UIMARCAUTH-411) Send requests for Source Files Settings with current tenant id.
-- [UIMARCAUTH-404](https://issues.folio.org/browse/UIMARCAUTH-404) Focus on record title after closing record details view.
+- [UIMARCAUTH-404](https://issues.folio.org/browse/UIMARCAUTH-404) Focus on record title after closing record details view, on search field after canceling record creation, on close record details view icon after closing quick-marc.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/src/routes/AuthorityQuickMarcRoute/AuthorityQuickMarcRoute.js
+++ b/src/routes/AuthorityQuickMarcRoute/AuthorityQuickMarcRoute.js
@@ -32,7 +32,10 @@ const AuthorityQuickMarcRoute = () => {
     history.push({
       pathname: `/marc-authorities/authorities/${recordId ?? ''}`,
       search: location.search,
-      state: { editSuccessful: true },
+      state: {
+        editSuccessful: true,
+        isClosingFocused: true,
+      },
     });
   }, [setIsGoingToBaseURL, location.search, history]);
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -576,6 +576,7 @@ const AuthoritiesSearch = ({
   const renderHeadingRef = (authority, className) => {
     return (
       <TextLink
+        id={`record-title-${authority.id}`}
         className={className}
         to={formatAuthorityRecordLink(authority)}
       >

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -80,6 +80,7 @@ const AuthorityView = ({
   const location = useLocation();
   const stripes = useStripes();
 
+  const id = authority.data?.id;
   const isShared = authority.data?.shared;
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
   const tenantId = isShared ? centralTenantId : authority.data?.tenantId;
@@ -123,7 +124,8 @@ const AuthorityView = ({
       const commonSearchParams = omit(parsedSearchParams, ['authRefType', 'headingRef']);
       const newSearchParamsString = queryString.stringify(commonSearchParams);
 
-      document.querySelector(`[role="gridcell"] a[href="${location.pathname}${location.search}"]`)?.focus();
+      // focus on the title of the closed record in the results list
+      document.querySelector(`#record-title-${id}[href="${location.pathname}${location.search}"]`)?.focus();
 
       history.push({
         pathname: '/marc-authorities',
@@ -131,7 +133,7 @@ const AuthorityView = ({
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location.search],
+    [location.search, id],
   );
 
   const { exportRecords } = useAuthorityExport([authority?.data?.id]);
@@ -240,7 +242,7 @@ const AuthorityView = ({
           <PaneCloseLink
             autoFocus={location.state?.isClosingFocused}
             onClick={onClose}
-            aria-label={intl.formatMessage({ id: 'ui-marc-authorities.close.record' })}
+            aria-label={intl.formatMessage({ id: 'stripes-components.closeItem' }, { item: paneTitle })}
           />
         )}
         lastMenu={

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -23,6 +23,7 @@ import {
   Button,
   ConfirmationModal,
   Icon,
+  PaneCloseLink,
 } from '@folio/stripes/components';
 import {
   useStripes,
@@ -121,6 +122,8 @@ const AuthorityView = ({
       const parsedSearchParams = queryString.parse(location.search);
       const commonSearchParams = omit(parsedSearchParams, ['authRefType', 'headingRef']);
       const newSearchParamsString = queryString.stringify(commonSearchParams);
+
+      document.querySelector(`[role="gridcell"] a[href="${location.pathname}${location.search}"]`)?.focus();
 
       history.push({
         pathname: '/marc-authorities',
@@ -232,8 +235,14 @@ const AuthorityView = ({
         isPaneset={false}
         marcTitle={marcTitle}
         marc={markHighlightedFields(marcSource, authority, authorityMappingRules).data}
-        onClose={onClose}
         tenantId={authority.data.tenantId}
+        firstMenu={(
+          <PaneCloseLink
+            autoFocus={location.state?.isClosingFocused}
+            onClick={onClose}
+            aria-label={intl.formatMessage({ id: 'ui-marc-authorities.close.record' })}
+          />
+        )}
         lastMenu={
           <>
             {(hasEditPermission || hasDeletePermission) && (

--- a/src/views/AuthorityView/AuthorityView.test.js
+++ b/src/views/AuthorityView/AuthorityView.test.js
@@ -1,3 +1,5 @@
+import { createMemoryHistory } from 'history';
+
 import {
   fireEvent,
   render,
@@ -111,8 +113,11 @@ const authority = {
   isLoading: false,
 };
 
-const renderAuthorityView = (props = {}) => render(
-  <Harness selectedRecordCtxValue={[null, mockSetSelectedAuthorityRecordContext]}>
+const renderAuthorityView = (props = {}, { history } = {}) => render(
+  <Harness
+    history={history}
+    selectedRecordCtxValue={[null, mockSetSelectedAuthorityRecordContext]}
+  >
     <CommandList commands={defaultKeyboardShortcuts}>
       <AuthorityView
         marcSource={marcSource}
@@ -388,19 +393,34 @@ describe('Given AuthorityView', () => {
 
   describe('when click on Close button', () => {
     it('should handle setSelectedAuthorityRecordContext', () => {
-      const { getByLabelText } = renderAuthorityView();
+      const { getAllByRole } = renderAuthorityView();
 
-      fireEvent.click(getByLabelText('stripes-components.closeItem'));
+      fireEvent.click(getAllByRole('button', { name: 'stripes-components.closeItem' })[0]);
 
       expect(mockSetSelectedAuthorityRecordContext).toHaveBeenCalledWith(null);
     });
 
     it('should redirect to /marc-authorities', () => {
-      const { getByLabelText } = renderAuthorityView();
+      const { getAllByRole } = renderAuthorityView();
 
-      fireEvent.click(getByLabelText('stripes-components.closeItem'));
+      fireEvent.click(getAllByRole('button', { name: 'stripes-components.closeItem' })[0]);
 
       expect(mockHistoryPush).toHaveBeenCalled();
+    });
+
+    it('should focus on the title of the closed record in the results list', () => {
+      const history = createMemoryHistory();
+      const href = 'marc-authorities/authorities/authority-id?authRefType=Reference&headingRef=Beethoven%2C%20Ludwig';
+
+      history.push(href);
+
+      const spyQuerySelector = jest.spyOn(document, 'querySelector');
+
+      const { getAllByRole } = renderAuthorityView({}, { history });
+
+      fireEvent.click(getAllByRole('button', { name: 'stripes-components.closeItem' })[0]);
+
+      expect(spyQuerySelector).toHaveBeenCalledWith(`#record-title-authority-id[href="${href}"]`);
     });
   });
 

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -120,6 +120,5 @@
   "settings.manageAuthoritySourceFiles.confirmationModal.cancel": "No, do not delete",
   "settings.manageAuthoritySourceFiles.confirmationModal.confirm": "Yes, delete",
 
-  "error.defaultSaveError": "Error on saving data",
-  "close.record": "Close the record"
+  "error.defaultSaveError": "Error on saving data"
 }

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -120,5 +120,6 @@
   "settings.manageAuthoritySourceFiles.confirmationModal.cancel": "No, do not delete",
   "settings.manageAuthoritySourceFiles.confirmationModal.confirm": "Yes, delete",
 
-  "error.defaultSaveError": "Error on saving data"
+  "error.defaultSaveError": "Error on saving data",
+  "close.record": "Close the record"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
1. Focus on record title after closing record details view.
2. Focus on search field after canceling record creation.
3. Focus on close record details view icon after closing quick-marc.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Description
1. Use `querySelector` to find the correct record in the results list. It is important to use query parameters, not only id, since some records use the same id.
2. `isCursorAtEnd` is used in a related PR to have a cursor at the end of the entered search term.
3. The `isClosingFocused` flag is used in `location.state` to track redirection from `quick-marc`.

## Related PRs
https://github.com/folio-org/stripes-marc-components/pull/21
https://github.com/folio-org/stripes-authority-components/pull/153

## Issues
[UIMARCAUTH-404](https://folio-org.atlassian.net/browse/UIMARCAUTH-404)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

https://github.com/folio-org/ui-marc-authorities/assets/77053927/bb37a294-c242-4168-86ef-70d631be7cb9





<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
