### PR TITLE
UIMARCAUTH-423: Pass `sortableColumns` to the MCL and revert `onInteractiveHeaders` (follow-up).

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -149,7 +149,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -157,7 +157,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -102,7 +102,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -110,7 +110,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -80,7 +80,7 @@ import css from './AuthoritiesSearch.css';
 import { REPORT_TYPES } from './constants';
 
 const prefix = 'authorities';
-const NON_INTERACTIVE_HEADERS = Object.values(searchResultListColumns).filter(column => !sortableColumns.includes(column));
+const NON_INTERACTIVE_HEADERS = [searchResultListColumns.SELECT];
 
 const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
@@ -643,6 +643,7 @@ const AuthoritiesSearch = ({
             loaded={isLoaded}
             visibleColumns={visibleColumns}
             showSortIndicator
+            sortableColumns={sortableColumns}
             sortedColumn={sortedColumn}
             sortOrder={sortOrder}
             onHeaderClick={onHeaderClick}

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -15,7 +15,10 @@ import authorities from '../../../mocks/authorities';
 
 import '../../../test/jest/__mock__';
 import Harness from '../../../test/jest/helpers/harness';
-import { sortOrders } from '../../constants';
+import {
+  sortableColumns,
+  sortOrders,
+} from '../../constants';
 import { useSortColumnManager } from '../../hooks';
 
 const mockHistoryPush = jest.fn();
@@ -505,7 +508,8 @@ describe('Given AuthoritiesSearch', () => {
     renderAuthoritiesSearch({ authorities });
 
     const expectedProps = {
-      nonInteractiveHeaders: ['select', 'link', 'numberOfTitles', 'authoritySource'],
+      nonInteractiveHeaders: ['select'],
+      sortableColumns,
     };
 
     expect(SearchResultsList).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Description
Follow-up PR.

After adding the `showSortIndicator` property and extending the `nonInteractiveHeaders`, the Tab key navigating through the results list headers only works for interactive fields (not in the `nonInteractiveHeaders` list).

Revert `nonInteractiveHeaders` and use sortableColumns for MCL to be able to navigate through all result list headers and keep the sort indicator.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/166

## Issues
[UIMARCAUTH-423](https://folio-org.atlassian.net/browse/UIMARCAUTH-423)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
![image](https://github.com/user-attachments/assets/b28ee758-5fdc-4c18-b5ab-f8f18cb71e65)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
