### PR TITLE
UIMARCAUTH-413 Move `quick-marc` to optional dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-411](https://issues.folio.org/browse/UIMARCAUTH-411) Send requests for Source Files Settings with current tenant id.
 - [UIMARCAUTH-404](https://issues.folio.org/browse/UIMARCAUTH-404) Focus on record title after closing record details view, on search field after canceling record creation, on close record details view icon after closing quick-marc.
 - [UIMARCAUTH-423](https://issues.folio.org/browse/UIMARCAUTH-423) Pass `showSortIndicator` prop to `SearchResultsList` to display sort indicator in the results header.
+- [UIMARCAUTH-413](https://issues.folio.org/browse/UIMARCAUTH-413) Move `quick-marc` to optional dependencies.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
     "rxjs": "^6.6.3"
   },
   "dependencies": {
-    "@folio/quick-marc": "^7.0.0",
     "@folio/stripes-acq-components": "~5.1.0",
     "@rehooks/local-storage": "^2.4.4",
     "query-string": "^7.0.1"
+  },
+  "optionalDependencies": {
+    "@folio/quick-marc": "^9.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",


### PR DESCRIPTION
## Description
We no longer import code from `ui-quick-marc`, so it can become an optional dependency just as a plugin

## Issues
[UIMARCAUTH-413](https://folio-org.atlassian.net/browse/UIMARCAUTH-413)