### PR TITLE
UIMARCAUTH-429 Upgrade srs interface and be permission refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [UIMARCAUTH-423](https://issues.folio.org/browse/UIMARCAUTH-423) Pass `showSortIndicator` prop to `SearchResultsList` to display sort indicator in the results header.
 - [UIMARCAUTH-413](https://issues.folio.org/browse/UIMARCAUTH-413) Move `quick-marc` to optional dependencies.
 - [UIMARCAUTH-428](https://issues.folio.org/browse/UIMARCAUTH-428) *BREAKING* Upgrade `marc-records-editor` to `6.0`.
+- [UIMARCAUTH-429](https://folio-org.atlassian.net/browse/UIMARCAUTH-429) Upgrade `source-record-storage` to `3.3`
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-marc-authorities
 
-## [5.1.0] (IN PROGRESS)
+## [6.0.0] (IN PROGRESS)
 
 - [UIMARCAUTH-408](https://issues.folio.org/browse/UIMARCAUTH-408) Import `useUserTenantPermissions` from `@folio/stripes/core`.
 - [UIMARCAUTH-396](https://issues.folio.org/browse/UIMARCAUTH-396) Add quickMARC shortcuts to modal.
@@ -12,7 +12,7 @@
 - [UIMARCAUTH-423](https://issues.folio.org/browse/UIMARCAUTH-423) Pass `showSortIndicator` prop to `SearchResultsList` to display sort indicator in the results header.
 - [UIMARCAUTH-413](https://issues.folio.org/browse/UIMARCAUTH-413) Move `quick-marc` to optional dependencies.
 - [UIMARCAUTH-428](https://issues.folio.org/browse/UIMARCAUTH-428) *BREAKING* Upgrade `marc-records-editor` to `6.0`.
-- [UIMARCAUTH-429](https://folio-org.atlassian.net/browse/UIMARCAUTH-429) Upgrade `source-record-storage` to `3.3`
+- [UIMARCAUTH-429](https://folio-org.atlassian.net/browse/UIMARCAUTH-429) *BREAKING* Upgrade `source-record-storage` to `3.3`
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/marc-authorities",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "MARC Authorities module",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-marc-authorities",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "okapiInterfaces": {
       "search": "1.0",
       "browse": "1.0",
-      "source-storage-records": "3.0",
+      "source-storage-records": "3.3",
       "marc-records-editor": "6.0"
     },
     "stripesDeps": [
@@ -109,7 +109,10 @@
           "marc-records-editor.links.suggestion.post",
           "search.authorities.collection.get",
           "search.facets.collection.get",
-          "source-storage.records.get",
+          "source-storage.records.collection.get",
+          "source-storage.records.item.get",
+          "source-storage.records.formatted.item.get",
+          "source-storage.stream.records.collection.get",
           "inventory-storage.authorities.item.get",
           "data-export.quick.export.post",
           "instance-authority.linking-rules.collection.get",


### PR DESCRIPTION
_Copied from [https://github.com/folio-org/ui-marc-authorities/pull/415](https://github.com/folio-org/ui-marc-authorities/pull/415)_

[UIMARCAUTH-429](https://folio-org.atlassian.net/browse/UIMARCAUTH-429) Update SRS interface version and refactor SRS BE permissions

## Purpose
According to the epic [FOLIO-4044](https://folio-org.atlassian.net/browse/FOLIO-4044) some permissions have been changed in the `source-record-storage v3.3`

permission u`i-marc-authorities.authority-record.view `uses `source-storage.records.get`


Old permission | New permissions
-- | --
source-storage.records.get | source-storage.stream.marc-record-identifiers.collection.postsource-storage.records.collection.getsource-storage.records.item.getsource-storage.records.formatted.item.getsource-storage.stream.records.collection.get source-storage.records.matching.collection.post


