### PR TITLE
UIMARCAUTH-422: Update required permissions for quick export of authority records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [UIMARCAUTH-429](https://folio-org.atlassian.net/browse/UIMARCAUTH-429) *BREAKING* Upgrade `source-record-storage` to `3.3`
 - [UIMARCAUTH-426](https://folio-org.atlassian.net/browse/UIMARCAUTH-426) migrate to shared CI workflows.
 - [UIMARCAUTH-430](https://folio-org.atlassian.net/browse/UIMARCAUTH-430) Refactor ui-inventory permissions.
+- [UIMARCAUTH-422](https://folio-org.atlassian.net/browse/UIMARCAUTH-422) Update required permissions for quick export of authority records.
 
 ## [5.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v5.0.1) (2024-04-02)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -152,6 +152,8 @@ const AuthoritiesSearch = ({
   const [reportsModalOpen, setReportsModalOpen] = useState(false);
   const selectedReport = useRef(null);
 
+  const canRunExport = stripes.hasPerm('ui-data-export.edit');
+
   const uniqueAuthoritiesCount = useMemo(() => {
     // determine count of unique ids in authorities array.
     // this is needed to check or uncheck "Select all" checkbox in header when all rows are explicitly
@@ -469,21 +471,23 @@ const AuthoritiesSearch = ({
           data-testid="menu-section-actions"
           label={intl.formatMessage({ id: 'ui-marc-authorities.actions' })}
         >
-          <Button
-            buttonStyle="dropdownItem"
-            id="dropdown-clickable-export-marc"
-            disabled={!selectedRowsCount}
-            onClick={() => {
-              exportRecords(selectedRowsIds);
-              onToggle();
-            }}
-          >
-            <Icon
-              icon="download"
-              size="medium"
-            />
-            <FormattedMessage id="ui-marc-authorities.export-selected-records" />
-          </Button>
+          {canRunExport && (
+            <Button
+              buttonStyle="dropdownItem"
+              id="dropdown-clickable-export-marc"
+              disabled={!selectedRowsCount}
+              onClick={() => {
+                exportRecords(selectedRowsIds);
+                onToggle();
+              }}
+            >
+              <Icon
+                icon="download"
+                size="medium"
+              />
+              <FormattedMessage id="ui-marc-authorities.export-selected-records" />
+            </Button>
+          )}
           <IfPermission perm="ui-marc-authorities.authority-record.create">
             <Button
               buttonStyle="dropdownItem"

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -116,6 +116,8 @@ const AuthorityView = ({
     ? hasCentralTenantPerm(centralTenantPermissions, editRecordPerm)
     : stripes.hasPerm(editRecordPerm);
 
+  const canRunExport = stripes.hasPerm('ui-data-export.edit');
+
   const onClose = useCallback(
     () => {
       setSelectedAuthorityRecordContext(null);
@@ -273,21 +275,23 @@ const AuthorityView = ({
                         </Icon>
                       </Button>
                     )}
-                    <Button
-                      buttonStyle="dropdownItem"
-                      id="dropdown-clickable-export-marc"
-                      onClick={() => {
-                        exportRecords([authority.data.id]);
-                        onToggle();
-                      }}
-                    >
-                      <Icon
-                        icon="download"
-                        size="medium"
+                    {canRunExport && (
+                      <Button
+                        buttonStyle="dropdownItem"
+                        id="dropdown-clickable-export-marc"
+                        onClick={() => {
+                          exportRecords([authority.data.id]);
+                          onToggle();
+                        }}
                       >
-                        <FormattedMessage id="ui-marc-authorities.authority-record.export" />
-                      </Icon>
-                    </Button>
+                        <Icon
+                          icon="download"
+                          size="medium"
+                        >
+                          <FormattedMessage id="ui-marc-authorities.authority-record.export" />
+                        </Icon>
+                      </Button>
+                    )}
                     <IfPermission perm="ui-marc-authorities.authority-record.view">
                       <Button
                         buttonStyle="dropdownItem"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIMARCAUTH-422

Here we added a check for `ui-data-export permissions` to run a quick export