### PR TITLE
UIMARCAUTH-438 Do not load MARC source until consortia data is available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-marc-authorities
 
+## [6.0.1] (IN PROGRESS)
+
+- [UIMARCAUTH-438](https://issues.folio.org/browse/UIMARCAUTH-438) Do not load MARC source until consortia data is available.
+
 ## [6.0.0](https://github.com/folio-org/ui-marc-authorities/tree/v6.0.0) (2024-11-01)
 
 - [UIMARCAUTH-408](https://issues.folio.org/browse/UIMARCAUTH-408) Import `useUserTenantPermissions` from `@folio/stripes/core`.

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -26,6 +26,22 @@ import {
 
 import { AuthorityView } from '../../views';
 
+const checkCanLoadMarcSource = (isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded) => {
+  if (!isAuthorityLoaded) {
+    return false;
+  }
+
+  if (!isConsortiaEnv) {
+    return true;
+  }
+
+  if (isShared && !isConsortiumDataLoaded) {
+    return false;
+  }
+
+  return true;
+};
+
 const AuthorityViewRoute = () => {
   const stripes = useStripes();
   const { params: { id } } = useRouteMatch();
@@ -64,7 +80,15 @@ const AuthorityViewRoute = () => {
   const authority = useAuthority({ recordId: id, authRefType, headingRef }, {
     onError: handleAuthorityLoadError,
   });
-  const marcSource = useMarcSource({ recordId: id, tenantId, enabled: Boolean(selectedAuthority) }, {
+
+  const isConsortiaEnv = stripes.hasInterface('consortium');
+  const isShared = selectedAuthority?.shared;
+  const isConsortiumDataLoaded = Boolean(stripes.user.user.consortium);
+  const isAuthorityLoaded = Boolean(selectedAuthority);
+
+  const isMarcSourceRequestEnabled = checkCanLoadMarcSource(isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded);
+
+  const marcSource = useMarcSource({ recordId: id, tenantId, enabled: isMarcSourceRequestEnabled }, {
     onError: handleAuthorityLoadError,
   });
 

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -26,7 +26,13 @@ import {
 
 import { AuthorityView } from '../../views';
 
-const checkCanLoadMarcSource = (isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded) => {
+const canLoadMarcSource = (isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded) => {
+  /*
+    There is a delay between loading consortia data and when it becomes available in `stripes.user.user`.
+    If an authority record is loaded before consortia data is available
+    then we fetch MARC source from a member tenant, which is incorrect for shared records
+    Because of this we need to have a more complex condition to enable MARC source requests at an appropriate time
+  */
   if (!isAuthorityLoaded) {
     return false;
   }
@@ -82,11 +88,11 @@ const AuthorityViewRoute = () => {
   });
 
   const isConsortiaEnv = stripes.hasInterface('consortium');
-  const isShared = selectedAuthority?.shared;
+  const isShared = Boolean(selectedAuthority?.shared);
   const isConsortiumDataLoaded = Boolean(stripes.user.user.consortium);
   const isAuthorityLoaded = Boolean(selectedAuthority);
 
-  const isMarcSourceRequestEnabled = checkCanLoadMarcSource(isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded);
+  const isMarcSourceRequestEnabled = canLoadMarcSource(isConsortiaEnv, isShared, isConsortiumDataLoaded, isAuthorityLoaded);
 
   const marcSource = useMarcSource({ recordId: id, tenantId, enabled: isMarcSourceRequestEnabled }, {
     onError: handleAuthorityLoadError,


### PR DESCRIPTION
## Description
Do not load MARC source until consortia data is available.
The issue was caused by a delay when loading consortia data. If an authority record is loaded before consortia data is available then we fetch MARC source from a member tenant, which is incorrect for shared records

## Screenshots


https://github.com/user-attachments/assets/34b660bc-e76d-45c9-825c-d188300a3455

## Issues
[UIMARCAUTH-438](https://folio-org.atlassian.net/browse/UIMARCAUTH-438)