### PR TITLE
UIMARCAUTH-445 MARC authority > View Source > Display Version History pane with an empty Version History component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-marc-authorities
 
+## [6.1.0] (IN PROGRESS)
+
+- [UIMARCAUTH-445](https://issues.folio.org/browse/UIMARCAUTH-445) MARC authority > View Source > Display Version History pane with an empty Version History component.
+
 ## [6.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v6.0.1) (2024-12-13)
 
 - [UIMARCAUTH-438](https://issues.folio.org/browse/UIMARCAUTH-438) Do not load MARC source until consortia data is available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/marc-authorities",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "MARC Authorities module",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-marc-authorities",

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -41,6 +41,11 @@ import {
   SelectedAuthorityRecordContext,
   useAuthorityMappingRules,
 } from '@folio/stripes-authority-components';
+import {
+  VersionHistoryButton,
+  VersionHistoryPane,
+  VersionViewContextProvider,
+} from '@folio/stripes-acq-components';
 
 import { KeyShortCutsWrapper } from '../../components';
 import { useAuthorityDelete } from '../../queries';
@@ -74,11 +79,12 @@ const AuthorityView = ({
   marcSource,
   authority,
 }) => {
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const stripes = useStripes();
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isHistoryPaneOpen, setIsHistoryPaneOpen] = useState(false);
 
   const id = authority.data?.id;
   const isShared = authority.data?.shared;
@@ -250,75 +256,97 @@ const AuthorityView = ({
         lastMenu={
           <>
             {(hasEditPermission || hasDeletePermission) && (
-              <Dropdown
-                renderTrigger={({ getTriggerProps }) => (
-                  <DropdownButton
-                    buttonStyle="primary"
-                    marginBottom0
-                    {...getTriggerProps()}
-                  >
-                    <FormattedMessage id="ui-marc-authorities.actions" />
-                  </DropdownButton>
-                )}
-                renderMenu={({ onToggle }) => (
-                  <DropdownMenu
-                    data-role="menu"
-                    aria-label="available options"
-                  >
-                    {canEditRecord && (
-                      <Button
-                        buttonStyle="dropdownItem"
-                        onClick={redirectToQuickMarcEditPage}
-                      >
-                        <Icon icon="edit">
-                          <FormattedMessage id="ui-marc-authorities.authority-record.edit" />
-                        </Icon>
-                      </Button>
-                    )}
-                    {canRunExport && (
-                      <Button
-                        buttonStyle="dropdownItem"
-                        id="dropdown-clickable-export-marc"
-                        onClick={() => {
-                          exportRecords([authority.data.id]);
-                          onToggle();
-                        }}
-                      >
-                        <Icon
-                          icon="download"
-                          size="medium"
+              <>
+                <Dropdown
+                  renderTrigger={({ getTriggerProps }) => (
+                    <DropdownButton
+                      buttonStyle="primary"
+                      marginBottom0
+                      {...getTriggerProps()}
+                    >
+                      <FormattedMessage id="ui-marc-authorities.actions" />
+                    </DropdownButton>
+                  )}
+                  renderMenu={({ onToggle }) => (
+                    <DropdownMenu
+                      data-role="menu"
+                      aria-label="available options"
+                    >
+                      {canEditRecord && (
+                        <Button
+                          buttonStyle="dropdownItem"
+                          onClick={redirectToQuickMarcEditPage}
                         >
-                          <FormattedMessage id="ui-marc-authorities.authority-record.export" />
-                        </Icon>
-                      </Button>
-                    )}
-                    <IfPermission perm="ui-marc-authorities.authority-record.view">
-                      <Button
-                        buttonStyle="dropdownItem"
-                        onClick={openPrintPopup}
-                      >
-                        <Icon icon="print">
-                          <FormattedMessage id="ui-marc-authorities.authority-record.print" />
-                        </Icon>
-                      </Button>
-                    </IfPermission>
-                    {canDeleteRecord && (
-                      <Button
-                        onClick={() => setDeleteModalOpen(true)}
-                        buttonStyle="dropdownItem"
-                      >
-                        <Icon icon="trash">
-                          <FormattedMessage id="ui-marc-authorities.authority-record.delete" />
-                        </Icon>
-                      </Button>
-                    )}
-                  </DropdownMenu>
-                )}
-              />
+                          <Icon icon="edit">
+                            <FormattedMessage id="ui-marc-authorities.authority-record.edit" />
+                          </Icon>
+                        </Button>
+                      )}
+                      {canRunExport && (
+                        <Button
+                          buttonStyle="dropdownItem"
+                          id="dropdown-clickable-export-marc"
+                          onClick={() => {
+                            exportRecords([authority.data.id]);
+                            onToggle();
+                          }}
+                        >
+                          <Icon
+                            icon="download"
+                            size="medium"
+                          >
+                            <FormattedMessage id="ui-marc-authorities.authority-record.export" />
+                          </Icon>
+                        </Button>
+                      )}
+                      <IfPermission perm="ui-marc-authorities.authority-record.view">
+                        <Button
+                          buttonStyle="dropdownItem"
+                          onClick={openPrintPopup}
+                        >
+                          <Icon icon="print">
+                            <FormattedMessage id="ui-marc-authorities.authority-record.print" />
+                          </Icon>
+                        </Button>
+                      </IfPermission>
+                      {canDeleteRecord && (
+                        <Button
+                          onClick={() => setDeleteModalOpen(true)}
+                          buttonStyle="dropdownItem"
+                        >
+                          <Icon icon="trash">
+                            <FormattedMessage id="ui-marc-authorities.authority-record.delete" />
+                          </Icon>
+                        </Button>
+                      )}
+                    </DropdownMenu>
+                  )}
+                />
+                <VersionHistoryButton onClick={() => setIsHistoryPaneOpen(true)} />
+              </>
             )}
           </>
         }
       />
+      {isHistoryPaneOpen && (
+        <VersionViewContextProvider
+          snapshotPath=""
+          versions={[]}
+          versionId={null}
+        >
+          <VersionHistoryPane
+            currentVersion={null}
+            id="authority"
+            isLoading={false}
+            onClose={() => setIsHistoryPaneOpen(false)}
+            onSelectVersion={() => {}}
+            snapshotPath=""
+            labelsMap={{}}
+            versions={[]}
+            hiddenFields={[]}
+          />
+        </VersionViewContextProvider>
+      )}
       <ConfirmationModal
         id="confirm-delete-note"
         open={deleteModalOpen}

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -270,7 +270,7 @@ const AuthorityView = ({
                   renderMenu={({ onToggle }) => (
                     <DropdownMenu
                       data-role="menu"
-                      aria-label="available options"
+                      aria-label={intl.formatMessage({ id: 'ui-marc-authorities.authority-record.menuOptions' })}
                     >
                       {canEditRecord && (
                         <Button

--- a/src/views/AuthorityView/AuthorityView.test.js
+++ b/src/views/AuthorityView/AuthorityView.test.js
@@ -436,4 +436,17 @@ describe('Given AuthorityView', () => {
       expect(queryByTestId('marc-view-pane')).toBeNull();
     });
   });
+
+  describe('when clicking on the version history button', () => {
+    it('should open a version history pane', () => {
+      const {
+        getByLabelText,
+        getByText,
+      } = renderAuthorityView();
+
+      fireEvent.click(getByLabelText('stripes-acq-components.versionHistory.pane.header'));
+
+      expect(getByText('stripes-acq-components.versionHistory.pane.sub')).toBeInTheDocument();
+    });
+  });
 });

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -21,6 +21,7 @@
 
   "search-results-list.numberOfTitles": "Number of titles",
 
+  "authority-record.menuOptions": "Available options",
   "authority-record.edit": "Edit",
   "authority-record.export": "Export (MARC)",
   "authority-record.print": "Print",


### PR DESCRIPTION
## Description
Added a version history button that opens a version history pane
mod-audit endpoint for version history is not complete yet, so actual requests will be done in scope of a different story

## Screenshots

https://github.com/user-attachments/assets/92bac149-129a-4b18-90a7-a1a0ab5c9d6c


## Issues
[UIMARCAUTH-445](https://folio-org.atlassian.net/browse/UIMARCAUTH-445)