### PR TITLE
UIMARCAUTH-452: Hide version history icon and settings if audit log feature is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UIMARCAUTH-447](https://issues.folio.org/browse/UIMARCAUTH-447) *BREAKING* Upgrade react-intl to v7.
 - [UIMARCAUTH-444](https://issues.folio.org/browse/UIMARCAUTH-444) *BREAKING* Create MARC authority settings to configure number of cards in version history.
 - [UIMARCAUTH-445](https://issues.folio.org/browse/UIMARCAUTH-445) MARC authority > View Source > Display Version History pane with an empty Version History component.
+- [UIMARCAUTH-452](https://issues.folio.org/browse/UIMARCAUTH-452) Hide version history icon and settings if audit log feature is disabled.
 
 ## [6.0.1](https://github.com/folio-org/ui-marc-authorities/tree/v6.0.1) (2024-12-13)
 

--- a/package.json
+++ b/package.json
@@ -162,7 +162,8 @@
         "displayName": "Settings (MARC authority): Module is enabled.",
         "subPermissions": [
           "settings.enabled",
-          "audit.config.groups.settings.collection.get"
+          "audit.config.groups.settings.collection.get",
+          "audit.config.groups.settings.audit.authority.collection.get"
         ],
         "visible": false
       },

--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
         "permissionName": "settings.marc-authorities.enabled",
         "displayName": "Settings (MARC authority): Module is enabled.",
         "subPermissions": [
-          "settings.enabled"
+          "settings.enabled",
+          "audit.config.groups.settings.collection.get"
         ],
         "visible": false
       },

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,2 +1,3 @@
 export const AUTHORITY_AUDIT_GROUP = 'audit.authority';
 export const VERSION_HISTORY_PAGE_SIZE_SETTING = 'records.page.size';
+export const VERSION_HISTORY_ENABLED_SETTING = 'enabled';

--- a/src/settings/MarcAuthoritySettings/MarcAuthoritySettings.js
+++ b/src/settings/MarcAuthoritySettings/MarcAuthoritySettings.js
@@ -8,16 +8,23 @@ import { TitleManager } from '@folio/stripes/core';
 import {
   CommandList,
   defaultKeyboardShortcuts,
+  LoadingPane,
 } from '@folio/stripes/components';
 import { Settings } from '@folio/stripes/smart-components';
 
 import { ManageAuthoritySourceFiles } from '../ManageAuthoritySourceFiles';
 import { VersionHistory } from '../VersionHistory';
+import { useAuditSettings } from '../../queries';
+import { VERSION_HISTORY_ENABLED_SETTING } from '../../constants';
 
 const MarcAuthoritySettings = () => {
   const match = useRouteMatch();
   const location = useLocation();
   const { formatMessage } = useIntl();
+
+  const { settings, isLoading: isLoadingSettings } = useAuditSettings();
+
+  const isVersionHistoryEnabled = settings?.find(setting => setting.key === VERSION_HISTORY_ENABLED_SETTING)?.value;
 
   const pages = [
     {
@@ -26,13 +33,19 @@ const MarcAuthoritySettings = () => {
       route: 'manage-authority-files',
       perm: 'ui-marc-authorities.settings.authority-files.view',
     },
-    {
-      component: VersionHistory,
-      label: formatMessage({ id: 'ui-marc-authorities.settings.versionHistory.pane.title' }),
-      route: 'version-history',
-      perm: 'ui-marc-authorities.settings.version-history',
-    },
+    ...(isVersionHistoryEnabled
+      ? [{
+        component: VersionHistory,
+        label: formatMessage({ id: 'ui-marc-authorities.settings.versionHistory.pane.title' }),
+        route: 'version-history',
+        perm: 'ui-marc-authorities.settings.version-history',
+      }]
+      : []),
   ];
+
+  if (isLoadingSettings) {
+    return <LoadingPane defaultWidth="15%" />;
+  }
 
   return (
     <CommandList commands={defaultKeyboardShortcuts}>

--- a/src/settings/MarcAuthoritySettings/MarcAuthoritySettings.test.js
+++ b/src/settings/MarcAuthoritySettings/MarcAuthoritySettings.test.js
@@ -4,6 +4,13 @@ import { Settings } from '@folio/stripes/smart-components';
 import Harness from '../../../test/jest/helpers/harness';
 
 import { MarcAuthoritySettings } from './MarcAuthoritySettings';
+import { useAuditSettings } from '../../queries';
+import { VERSION_HISTORY_ENABLED_SETTING } from '../../constants';
+
+jest.mock('../../queries', () => ({
+  ...jest.requireActual('../../queries'),
+  useAuditSettings: jest.fn(),
+}));
 
 const renderMarcAuthoritySettings = () => render(
   <Harness>
@@ -14,11 +21,51 @@ const renderMarcAuthoritySettings = () => render(
 describe('Given Settings', () => {
   beforeEach(() => {
     Settings.mockClear();
+
+    useAuditSettings.mockReturnValue({
+      settings: [{
+        key: VERSION_HISTORY_ENABLED_SETTING,
+        value: true,
+      }],
+      isLoading: false,
+    });
   });
 
   it('should be rendered', () => {
     const { getByText } = renderMarcAuthoritySettings();
 
     expect(getByText('Settings')).toBeVisible();
+  });
+
+  describe('when version history feature is not enabled', () => {
+    it('should not render Version History page', () => {
+      useAuditSettings.mockReturnValue({
+        settings: [{
+          key: VERSION_HISTORY_ENABLED_SETTING,
+          value: false,
+        }],
+        isLoading: false,
+      });
+
+      renderMarcAuthoritySettings();
+
+      expect(Settings.mock.calls[0][0].pages.find(page => page.route === 'version-history')).toBeUndefined();
+    });
+  });
+
+  describe('when version history settings are loading', () => {
+    it('should not render Version History page', () => {
+      useAuditSettings.mockReturnValue({
+        settings: [{
+          key: VERSION_HISTORY_ENABLED_SETTING,
+          value: true,
+        }],
+        isLoading: true,
+      });
+
+      const { queryByText } = renderMarcAuthoritySettings();
+
+      expect(queryByText('Settings')).toBeNull();
+    });
   });
 });

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -48,12 +48,16 @@ import {
 } from '@folio/stripes-acq-components';
 
 import { KeyShortCutsWrapper } from '../../components';
-import { useAuthorityDelete } from '../../queries';
+import {
+  useAuditSettings,
+  useAuthorityDelete,
+} from '../../queries';
 import {
   hasCentralTenantPerm,
   isConsortiaEnv,
 } from '../../utils';
 import { useAuthorityExport } from '../../hooks';
+import { VERSION_HISTORY_ENABLED_SETTING } from '../../constants';
 
 import css from './AuthorityView.css';
 
@@ -108,6 +112,7 @@ const AuthorityView = ({
   });
 
   const { authorityMappingRules } = useAuthorityMappingRules({ tenantId, enabled: Boolean(authority.data) });
+  const { settings, isLoading: isLoadingSettings } = useAuditSettings();
 
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
@@ -125,6 +130,7 @@ const AuthorityView = ({
     : stripes.hasPerm(editRecordPerm);
 
   const canRunExport = stripes.hasPerm('ui-data-export.edit');
+  const isVersionHistoryEnabled = settings?.find(setting => setting.key === VERSION_HISTORY_ENABLED_SETTING)?.value;
 
   const onClose = useCallback(
     () => {
@@ -325,7 +331,11 @@ const AuthorityView = ({
                     </DropdownMenu>
                   )}
                 />
-                <VersionHistoryButton onClick={() => setIsHistoryPaneOpen(true)} />
+                {!isLoadingSettings && isVersionHistoryEnabled && (
+                  <VersionHistoryButton
+                    onClick={() => setIsHistoryPaneOpen(true)}
+                  />
+                )}
               </>
             )}
           </>

--- a/src/views/AuthorityView/AuthorityView.test.js
+++ b/src/views/AuthorityView/AuthorityView.test.js
@@ -15,6 +15,8 @@ import Harness from '../../../test/jest/helpers/harness';
 import AuthorityView from './AuthorityView';
 import { useAuthorityExport } from '../../hooks';
 import { openEditShortcut } from '../../../test/utilities';
+import { useAuditSettings } from '../../queries';
+import { VERSION_HISTORY_ENABLED_SETTING } from '../../constants';
 
 const mockHistoryPush = jest.fn();
 const mockSetSelectedAuthorityRecordContext = jest.fn();
@@ -47,6 +49,11 @@ jest.mock('@folio/stripes/components', () => ({
 
 jest.mock('../../hooks', () => ({
   useAuthorityExport: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../queries', () => ({
+  ...jest.requireActual('../../queries'),
+  useAuditSettings: jest.fn(),
 }));
 
 const marcSource = {
@@ -138,6 +145,13 @@ describe('Given AuthorityView', () => {
     useUserTenantPermissions.mockReturnValue({
       userPermissions: [],
       isFetching: false,
+    });
+    useAuditSettings.mockReturnValue({
+      settings: [{
+        key: VERSION_HISTORY_ENABLED_SETTING,
+        value: true,
+      }],
+      isLoading: false,
     });
   });
 
@@ -447,6 +461,22 @@ describe('Given AuthorityView', () => {
       fireEvent.click(getByLabelText('stripes-acq-components.versionHistory.pane.header'));
 
       expect(getByText('stripes-acq-components.versionHistory.pane.sub')).toBeInTheDocument();
+    });
+  });
+
+  describe('when version history feature is not enabled', () => {
+    it('should not display the version history button', () => {
+      useAuditSettings.mockReturnValue({
+        settings: [{
+          key: VERSION_HISTORY_ENABLED_SETTING,
+          value: false,
+        }],
+        isLoading: false,
+      });
+
+      const { queryByLabelText } = renderAuthorityView();
+
+      expect(queryByLabelText('stripes-acq-components.versionHistory.pane.header')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Hide version history icon and settings if audit log feature is disabled.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
[UIMARCAUTH-452](https://folio-org.atlassian.net/browse/UIMARCAUTH-452)

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
