### PR TITLE
UIMARCAUTH-477 Move focus on the detail view pane when record is opened automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UIMARCAUTH-456](https://issues.folio.org/browse/UIMARCAUTH-456) Add version 1.3 to the `search` interface.
 - [UIMARCAUTH-462](https://issues.folio.org/browse/UIMARCAUTH-462) replace moment with day.js
+- [UIMARCAUTH-477](https://issues.folio.org/browse/UIMARCAUTH-477) Move focus on the detail view pane when record is opened automatically.
 
 ## [7.0.0](https://github.com/folio-org/ui-marc-authorities/tree/v7.0.0) (2025-03-13)
 

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -2,6 +2,8 @@ import {
   useContext,
   useCallback,
   useState,
+  useRef,
+  useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -88,6 +90,7 @@ const AuthorityView = ({
   const stripes = useStripes();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isHistoryPaneOpen, setIsHistoryPaneOpen] = useState(false);
+  const paneTitleRef = useRef(null);
 
   const id = authority.data?.id;
   const isShared = authority.data?.shared;
@@ -177,6 +180,12 @@ const AuthorityView = ({
     },
   });
 
+  useEffect(() => {
+    if (!marcSource.isLoading && !authority.isLoading) {
+      paneTitleRef.current?.focus();
+    }
+  }, [marcSource.isLoading, authority.isLoading]);
+
   if (marcSource.isLoading || authority.isLoading || isCentralTenantPermissionsLoading) {
     return <LoadingPane id="marc-view-pane" />;
   }
@@ -236,6 +245,9 @@ const AuthorityView = ({
       <MarcView
         paneWidth="40%"
         paneTitle={paneTitle}
+        paneProps={{
+          paneTitleRef,
+        }}
         paneSub={intl.formatMessage(
           {
             id: 'stripes-authority-components.authorityRecordSubtitle',


### PR DESCRIPTION
## Description
Move focus on the detail view pane when record is opened automatically

## Screenshots

https://github.com/user-attachments/assets/7b9044c9-72cd-4a94-90db-542c73a6fe6f


## Issues
[UIMARCAUTH-477](https://folio-org.atlassian.net/browse/UIMARCAUTH-477)