### PR TITLE
UIMARCAUTH-477 wait for central tenant permissions to load before focusing third pane (follow-up)

### DIFF
--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -181,11 +181,7 @@ const AuthorityView = ({
   });
 
   useEffect(() => {
-    if (isCentralTenantPermissionsLoading) {
-      return;
-    }
-
-    if (!marcSource.isLoading && !authority.isLoading) {
+    if (!marcSource.isLoading && !authority.isLoading && !isCentralTenantPermissionsLoading) {
       paneTitleRef.current?.focus();
     }
   }, [isCentralTenantPermissionsLoading, marcSource.isLoading, authority.isLoading]);

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -181,10 +181,14 @@ const AuthorityView = ({
   });
 
   useEffect(() => {
+    if (isCentralTenantPermissionsLoading) {
+      return;
+    }
+
     if (!marcSource.isLoading && !authority.isLoading) {
       paneTitleRef.current?.focus();
     }
-  }, [marcSource.isLoading, authority.isLoading]);
+  }, [isCentralTenantPermissionsLoading, marcSource.isLoading, authority.isLoading]);
 
   if (marcSource.isLoading || authority.isLoading || isCentralTenantPermissionsLoading) {
     return <LoadingPane id="marc-view-pane" />;


### PR DESCRIPTION
## Description
Need to wait for central tenant permissions to load because it is also a condition to show loading pane. Focusing before permissions are loaded has no effect on the third pane.

## Issues
[UIMARCAUTH-477](https://folio-org.atlassian.net/browse/UIMARCAUTH-477)