### PR TITLE
UIMARCAUTH-490 hide "Save Authorities cql" button in Authorities Browse (follow-up)

### DIFF
--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -502,22 +502,24 @@ const AuthoritiesSearch = ({
             </Icon>
           </Button>
         </IfPermission>
-        <Button
-          buttonStyle="dropdownItem"
-          id="dropdown-clickable-export-cql"
-          disabled={!authorities.length}
-          onClick={() => {
-            onGenerateCQLQueryReport();
-            onToggle();
-          }}
-        >
-          <Icon
-            icon="search"
-            size="medium"
+        {navigationSegmentValue === navigationSegments.search && (
+          <Button
+            buttonStyle="dropdownItem"
+            id="dropdown-clickable-export-cql"
+            disabled={!authorities.length}
+            onClick={() => {
+              onGenerateCQLQueryReport();
+              onToggle();
+            }}
           >
-            <FormattedMessage id="ui-marc-authorities.export-cql-query" />
-          </Icon>
-        </Button>
+            <Icon
+              icon="search"
+              size="medium"
+            >
+              <FormattedMessage id="ui-marc-authorities.export-cql-query" />
+            </Icon>
+          </Button>
+        )}
         {navigationSegmentValue !== navigationSegments.browse &&
           <MenuSection
             data-testid="menu-section-sort-by"

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -8,6 +8,7 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import { runAxeTest } from '@folio/stripes-testing';
 import {
+  navigationSegments,
   searchResultListColumns,
   SearchResultsList,
 } from '@folio/stripes-authority-components';
@@ -79,6 +80,7 @@ const getAuthoritiesSearch = (props = {}, selectedRecord = null, authoritiesCtxV
       searchQuery: '',
       filters: [],
       setSortedColumn: mockSetSortedColumn,
+      navigationSegmentValue: navigationSegments.search,
       ...authoritiesCtxValue,
     }}
   >
@@ -192,6 +194,20 @@ describe('Given AuthoritiesSearch', () => {
 
       expect(exportRecordsButton).toBeDefined();
       expect(exportRecordsButton).toBeDisabled();
+    });
+
+    describe('when in Browse mode', () => {
+      it('should not display "Save authorities CQL query" button', () => {
+        const { getByRole, queryByRole } = renderAuthoritiesSearch(null, null, {
+          navigationSegmentValue: navigationSegments.browse,
+        });
+
+        fireEvent.click(getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' }));
+
+        const exportRecordsButton = queryByRole('button', { name: 'ui-marc-authorities.export-cql-query' });
+
+        expect(exportRecordsButton).not.toBeInTheDocument();
+      });
     });
 
     describe('when search results list contains at least 1 authority', () => {


### PR DESCRIPTION
## Description
A follow-up PR to hide "Save Authorities CQL query" button when in Browse.

## Screenshots
![image](https://github.com/user-attachments/assets/9cefda1c-62b6-4054-b9eb-8a6a6bd59cc0)


## Issues
[UIMARCAUTH-490](https://folio-org.atlassian.net/browse/UIMARCAUTH-490)