### PR TITLE
UIMARCAUTH-497 Do not show Save authorities UUIDs (CSV) option when user selects Browse toggle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UIMARCAUTH-493](https://issues.folio.org/browse/UIMARCAUTH-493) Authority View - show Last updated by date from mod-search metadata.
 - [UIMARCAUTH-491](https://issues.folio.org/browse/UIMARCAUTH-491) *BREAKING* MARC authority app: Ability to save all authority UUIDs.
 - [UIMARCAUTH-501](https://issues.folio.org/browse/UIMARCAUTH-501) *BREAKING* Update for split search & browse APIs.
+- [UIMARCAUTH-497](https://issues.folio.org/browse/UIMARCAUTH-497) Do not show Save authorities UUIDs (CSV) option when user selects Browse toggle.
 
 ## [7.0.2] (https://github.com/folio-org/ui-marc-authorities/tree/v7.0.2) (2025-04-14)
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -528,16 +528,21 @@ const AuthoritiesSearch = ({
             </Icon>
           </Button>
         </IfPermission>
-        <Button
-          buttonStyle="dropdownItem"
-          id="dropdown-clickable-export-uuids"
-          disabled={!authorities.length}
-          onClick={onGenerateAuthoritiesUUIDsReport}
-        >
-          <Icon icon="save">
-            <FormattedMessage id="ui-marc-authorities.actions.saveAuthoritiesUIIDS" />
-          </Icon>
-        </Button>
+        {navigationSegmentValue === navigationSegments.search && (
+          <Button
+            buttonStyle="dropdownItem"
+            id="dropdown-clickable-export-uuids"
+            disabled={!authorities.length}
+            onClick={() => {
+              onGenerateAuthoritiesUUIDsReport();
+              onToggle();
+            }}
+          >
+            <Icon icon="save">
+              <FormattedMessage id="ui-marc-authorities.actions.saveAuthoritiesUIIDS" />
+            </Icon>
+          </Button>
+        )}
         <IfPermission perm="ui-data-export.edit">
           <Button
             buttonStyle="dropdownItem"

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -227,13 +227,15 @@ describe('Given AuthoritiesSearch', () => {
       });
 
       it('should not show Save Authorities UUIDs button', () => {
-        renderAuthoritiesSearch();
+        renderAuthoritiesSearch(null, null, {
+          navigationSegmentValue: navigationSegments.browse,
+        });
 
         fireEvent.click(screen.getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' }));
 
         const saveAuthoritiesUIIDSButton = screen.queryByRole('button', { name: 'ui-marc-authorities.actions.saveAuthoritiesUIIDS' });
 
-        expect(saveAuthoritiesUIIDSButton).toBeNull();
+        expect(saveAuthoritiesUIIDSButton).not.toBeInTheDocument();
       });
     });
 

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.test.js
@@ -225,6 +225,16 @@ describe('Given AuthoritiesSearch', () => {
 
         expect(exportRecordsButton).not.toBeInTheDocument();
       });
+
+      it('should not show Save Authorities UUIDs button', () => {
+        renderAuthoritiesSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: 'stripes-components.paneMenuActionsToggleLabel' }));
+
+        const saveAuthoritiesUIIDSButton = screen.queryByRole('button', { name: 'ui-marc-authorities.actions.saveAuthoritiesUIIDS' });
+
+        expect(saveAuthoritiesUIIDSButton).toBeNull();
+      });
     });
 
     describe('when search results list contains at least 1 authority', () => {


### PR DESCRIPTION
## Description
Do not show Save authorities UUIDs (CSV) option when user selects Browse toggle.

## Screenshots
<img width="1919" height="864" alt="image" src="https://github.com/user-attachments/assets/bd0e15a2-2c73-4135-beed-6395b3bc0fce" />

## Issues
[UIMARCAUTH-497](https://folio-org.atlassian.net/browse/UIMARCAUTH-497)