### PR TITLE
UIMARCAUTH-511 proptypes typo

### DIFF
--- a/src/components/AuthorityTitleManager/AuthorityTitleManager.js
+++ b/src/components/AuthorityTitleManager/AuthorityTitleManager.js
@@ -12,7 +12,7 @@ import {
 } from '@folio/stripes-authority-components';
 
 const propTypes = {
-  children: PropTypes.oneOfType(PropTypes.node, PropTypes.arrayOf(PropTypes.node)),
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
 };
 
 const AuthorityTitleManager = ({ children = null }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ import commands from './commands';
 const propTypes = {
   focusSearchField: PropTypes.func,
   match: PropTypes.object.isRequired,
-  showSettings: PropTypes.bool.isRequired,
+  showSettings: PropTypes.bool,
 };
 
 const MarcAuthorities = ({

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -98,7 +98,7 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
   error: PropTypes.object,
-  firstPageQuery: PropTypes.string.isRequired,
+  firstPageQuery: PropTypes.string,
   handleLoadMore: PropTypes.func.isRequired,
   hasNextPage: PropTypes.bool,
   hasPrevPage: PropTypes.bool,


### PR DESCRIPTION
`PropTypes.oneOfType` expects an array.
```
-  children: PropTypes.oneOfType(PropTypes.node, PropTypes.arrayOf(PropTypes.node)),
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
```