### PR TITLE
UIMARCAUTH-527 Remove unused marc-records-editor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [UIMARCAUTH-518](https://issues.folio.org/browse/UIMARCAUTH-518) Define separate routes for Create/Edit MARC Authorities.
 - [UIMARCAUTH-519](https://issues.folio.org/browse/UIMARCAUTH-519) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
 - [UIMARCAUTH-514](https://issues.folio.org/browse/UIMARCAUTH-514) include global permissions in package.json base permissions.
-
+- [UIMARCAUTH-527](https://issues.folio.org/browse/UIMARCAUTH-527) Remove unused marc-records-editor interface.
 
 ## [7.0.2] (https://github.com/folio-org/ui-marc-authorities/tree/v7.0.2) (2025-04-14)
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
       "search-facets": "1.0",
       "browse-authorities": "1.0",
       "source-storage-records": "3.3",
-      "marc-records-editor": "6.0",
       "resource-ids-streaming": "1.0"
     },
     "optionalOkapiInterfaces": {


### PR DESCRIPTION
## Description

ui-marc-authorities no longer requires `marc-records-editor` interface after we removed a call to fetch number of links in https://github.com/folio-org/ui-marc-authorities/pull/482, so we should remove it from okapiInterfaces

## Issues
[UIMARCAUTH-527](https://folio-org.atlassian.net/browse/UIMARCAUTH-527)