### PR TITLE
UIMARCAUTH-528 use the new `fetchAuthority` function from `useAuthority` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [UIMARCAUTH-519](https://issues.folio.org/browse/UIMARCAUTH-519) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
 - [UIMARCAUTH-514](https://issues.folio.org/browse/UIMARCAUTH-514) include global permissions in package.json base permissions.
 - [UIMARCAUTH-527](https://issues.folio.org/browse/UIMARCAUTH-527) Remove unused marc-records-editor interface.
+- [UIMARCAUTH-528](https://issues.folio.org/browse/UIMARCAUTH-528) use the new `fetchAuthority` function from `useAuthority` hook.
 
 ## [7.0.2] (https://github.com/folio-org/ui-marc-authorities/tree/v7.0.2) (2025-04-14)
 

--- a/src/routes/EditMarcAuthorityRoute/EditMarcAuthorityRoute.js
+++ b/src/routes/EditMarcAuthorityRoute/EditMarcAuthorityRoute.js
@@ -34,19 +34,18 @@ export const EditMarcAuthorityRoute = () => {
 
   const { externalId } = match.params;
   const searchParams = new URLSearchParams(location.search);
+  const headingRef = searchParams.get('headingRef');
+  const authRefType = searchParams.get('authRefType');
+
   const isShared = searchParams.get('shared') === 'true';
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
 
-  const { refetch } = useAuthority({
+  const { fetchAuthority } = useAuthority({
     recordId: externalId,
+    headingRef,
+    authRefType,
     tenantId: isShared ? centralTenantId : '',
   });
-
-  const fetchAuthority = async () => {
-    const { data } = await refetch();
-
-    return data;
-  };
 
   const onClose = useCallback(recordRoute => {
     setIsGoingToBaseURL(false);

--- a/src/routes/EditMarcAuthorityRoute/EditMarcAuthorityRoute.test.js
+++ b/src/routes/EditMarcAuthorityRoute/EditMarcAuthorityRoute.test.js
@@ -81,6 +81,8 @@ describe('EditMarcAuthorityRoute', () => {
     renderEditMarcAuthorityRoute();
 
     expect(useAuthority).toHaveBeenCalledWith({
+      authRefType: null,
+      headingRef: null,
       recordId: 'id',
       tenantId: '',
     });


### PR DESCRIPTION
## Description
use the new `fetchAuthority` function from `useAuthority` hook to pass a single record to quickMARC

## Issues
[UIMARCAUTH-528](https://folio-org.atlassian.net/browse/UIMARCAUTH-528)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/219