### PR TITLE
UIMARCAUTH-530 Retry fetching a created Authority record when reindexing is still in progress.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-marc-authorities
 
+## [8.1.0] (IN PROGRESS)
+
+- [UIMARCAUTH-530](https://issues.folio.org/browse/UIMARCAUTH-530) Retry fetching a created Authority record when reindexing is still in progress.
+
 ## [8.0.0] (https://github.com/folio-org/ui-marc-authorities/tree/v8.0.0) (2026-04-17)
 
 - [UIMARCAUTH-462](https://issues.folio.org/browse/UIMARCAUTH-462) replace moment with day.js

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -83,7 +83,7 @@ const AuthorityViewRoute = () => {
   };
 
   // There is no need to change the tenant for this API.
-  const authority = useAuthority({ recordId: id, authRefType, headingRef }, {
+  const authority = useAuthority({ recordId: id, authRefType, headingRef, refetchOnEmptyResults: location.state?.isNewRecord }, {
     onError: handleAuthorityLoadError,
   });
 
@@ -99,10 +99,18 @@ const AuthorityViewRoute = () => {
   });
 
   useEffect(() => {
-    if (authority && !selectedAuthority) {
-      setSelectedAuthority(authority.data);
+    if (authority?.data && !selectedAuthority) {
+      setSelectedAuthority(authority?.data);
     }
-  }, [authority?.data?.id]);
+  }, [authority?.data, setSelectedAuthority, selectedAuthority]);
+
+  useEffect(() => {
+    if (authority?.data) {
+      history.replace({
+        state: { ...location.state, isNewRecord: false },
+      });
+    }
+  }, [authority?.data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <AuthorityView

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
@@ -1,5 +1,6 @@
-import { render } from '@folio/jest-config-stripes/testing-library/react';
+import { useHistory } from 'react-router';
 
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 import {
   useMarcSource,
   useAuthority,
@@ -11,6 +12,11 @@ import AuthorityViewRoute from './AuthorityViewRoute';
 import Harness from '../../../test/jest/helpers/harness';
 
 const mockSendCallout = jest.fn().mockName('sendCalloutMock');
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useHistory: jest.fn(),
+}));
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
@@ -36,7 +42,9 @@ jest.mock('@folio/stripes/core', () => ({
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useMarcSource: jest.fn(),
-  useAuthority: jest.fn(),
+  useAuthority: jest.fn().mockReturnValue({
+    data: {},
+  }),
 }));
 
 jest.mock('../../views/AuthorityView/AuthorityView', () => function () {
@@ -49,9 +57,15 @@ const renderAuthorityViewRoute = (selectedRecordCtxValue) => render(
   </Harness>,
 );
 
+const mockHistoryReplace = jest.fn();
+
 describe('Given AuthorityViewRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useHistory.mockReturnValue({
+      replace: mockHistoryReplace,
+      push: jest.fn(),
+    });
   });
 
   it('should render with no axe errors', async () => {
@@ -66,6 +80,16 @@ describe('Given AuthorityViewRoute', () => {
     const { getByText } = renderAuthorityViewRoute();
 
     expect(getByText('AuthorityView')).toBeDefined();
+  });
+
+  describe('when authority is loaded', () => {
+    it('should reset `isNewRecord` history state parameter', () => {
+      renderAuthorityViewRoute();
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith(expect.objectContaining({
+        state: { isNewRecord: false },
+      }));
+    });
   });
 
   describe('when marc source request failed', () => {

--- a/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.js
+++ b/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.js
@@ -18,7 +18,7 @@ export const CreateMarcAuthorityRoute = () => {
   const searchParams = new URLSearchParams(location.search);
   const isShared = searchParams.get('shared') === 'true';
 
-  const onClose = useCallback(recordRoute => {
+  const redirectToAuthorityView = useCallback((recordRoute, isNewRecord = false) => {
     setIsGoingToBaseURL(false);
 
     const newSearchParams = new URLSearchParams(location.search);
@@ -30,9 +30,18 @@ export const CreateMarcAuthorityRoute = () => {
       search: newSearchParams.toString(),
       state: {
         isClosingFocused: true,
+        isNewRecord,
       },
     });
   }, [location.search, history, setIsGoingToBaseURL]);
+
+  const onClose = useCallback(recordRoute => {
+    redirectToAuthorityView(recordRoute);
+  }, [redirectToAuthorityView]);
+
+  const onSave = useCallback(recordRoute => {
+    redirectToAuthorityView(recordRoute, true);
+  }, [redirectToAuthorityView]);
 
   const onCreateAndKeepEditing = useCallback(id => {
     history.push(`edit-authority/${id}`);
@@ -43,7 +52,7 @@ export const CreateMarcAuthorityRoute = () => {
       <Pluggable
         type="quick-marc"
         onClose={onClose}
-        onSave={onClose}
+        onSave={onSave}
         externalRecordPath="/marc-authorities/authorities"
         action="create"
         marcType="authority"

--- a/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
+++ b/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
@@ -88,7 +88,7 @@ describe('CreateMarcAuthorityRoute', () => {
       expect(mockPush).toHaveBeenCalledWith({
         pathname: '/marc-authorities/authorities/id',
         search: '',
-        state: { isClosingFocused: true },
+        state: { isClosingFocused: true, isNewRecord: true },
       });
     });
   });
@@ -101,7 +101,7 @@ describe('CreateMarcAuthorityRoute', () => {
       expect(mockPush).toHaveBeenCalledWith({
         pathname: '/marc-authorities/authorities/id',
         search: '',
-        state: { isClosingFocused: true },
+        state: { isClosingFocused: true, isNewRecord: false },
       });
     });
   });


### PR DESCRIPTION
## Description
Retry fetching a created Authority record when reindexing is still in progress.
After creating a new MARC Authority record and redirecting to that record - sometimes reindexing process can take too long and users will see an empty page.
To mitigate this we can try refetching the new record several times.

The flow is:
1. After creating a new MARC Authority record - redirect to Authority View with a history state parameter `isNewRecord=true`.
2. This parameter is passed to `useAuthority` hook as `refetchOnEmptyResults`.
3. `useAuthority` checks that if `refetchOnEmptyResults` is true and no results are returned - it will make another request for this record until we get a non-emptry response or reach an attempt limit.
4. When we get a non-empty result - `isNewRecord` state parameter is cleared.

## Issues
[UIMARCAUTH-530](https://folio-org.atlassian.net/browse/UIMARCAUTH-530)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/225