### PR TITLE
UIMARCAUTH-537 Fix Authority View pane keeps opening and closing in Browse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-marc-authorities
 
+## [8.1.0] (IN PROGRESS)
+
+- [UIMARCAUTH-537](https://issues.folio.org/browse/UIMARCAUTH-537) Fix Authority View pane keeps opening and closing in Browse.
+
 ## [8.0.1] (https://github.com/folio-org/ui-marc-authorities/tree/v8.0.1) (2026-05-28)
 
 - [UIMARCAUTH-530](https://issues.folio.org/browse/UIMARCAUTH-530) Retry fetching a created Authority record when reindexing is still in progress.

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -105,6 +105,11 @@ const AuthorityViewRoute = () => {
   }, [authority?.data, setSelectedAuthority, selectedAuthority]);
 
   useEffect(() => {
+    // `isNewRecord` is set in `CreateMarcAuthorityRoute` and is needed to
+    // retry feching a created Authority record. The record might not be
+    // available via search immediately after creation since reindexing might take
+    // a few moments.
+    // After we've successfully fetched this record - we should reset `isNewRecord` to false
     if (authority?.data && location.state?.isNewRecord) {
       history.replace({
         state: { ...location.state, isNewRecord: false },

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -105,7 +105,7 @@ const AuthorityViewRoute = () => {
   }, [authority?.data, setSelectedAuthority, selectedAuthority]);
 
   useEffect(() => {
-    if (authority?.data) {
+    if (authority?.data && location.state?.isNewRecord) {
       history.replace({
         state: { ...location.state, isNewRecord: false },
       });

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
@@ -4,10 +4,7 @@ import {
 } from 'react-router';
 
 import { render } from '@folio/jest-config-stripes/testing-library/react';
-import {
-  useMarcSource,
-  useAuthority,
-} from '@folio/stripes-authority-components';
+import { useMarcSource } from '@folio/stripes-authority-components';
 import { useStripes } from '@folio/stripes/core';
 import { runAxeTest } from '@folio/stripes-testing';
 

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
@@ -1,4 +1,7 @@
-import { useHistory } from 'react-router';
+import {
+  useHistory,
+  useLocation,
+} from 'react-router';
 
 import { render } from '@folio/jest-config-stripes/testing-library/react';
 import {
@@ -16,6 +19,9 @@ const mockSendCallout = jest.fn().mockName('sendCalloutMock');
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useHistory: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    state: {},
+  }),
 }));
 
 jest.mock('@folio/stripes/core', () => ({
@@ -66,6 +72,7 @@ describe('Given AuthorityViewRoute', () => {
       replace: mockHistoryReplace,
       push: jest.fn(),
     });
+    mockHistoryReplace.mockClear();
   });
 
   it('should render with no axe errors', async () => {
@@ -83,12 +90,38 @@ describe('Given AuthorityViewRoute', () => {
   });
 
   describe('when authority is loaded', () => {
-    it('should reset `isNewRecord` history state parameter', () => {
-      renderAuthorityViewRoute();
+    describe('and `isNewRecord` state parameter is true', () => {
+      beforeEach(() => {
+        useLocation.mockReturnValue({
+          state: {
+            isNewRecord: true,
+          },
+        });
+      });
 
-      expect(mockHistoryReplace).toHaveBeenCalledWith(expect.objectContaining({
-        state: { isNewRecord: false },
-      }));
+      it('should reset `isNewRecord` history state parameter', () => {
+        renderAuthorityViewRoute();
+
+        expect(mockHistoryReplace).toHaveBeenCalledWith(expect.objectContaining({
+          state: { isNewRecord: false },
+        }));
+      });
+    });
+
+    describe('and `isNewRecord` state parameter is false', () => {
+      beforeEach(() => {
+        useLocation.mockReturnValue({
+          state: {
+            isNewRecord: false,
+          },
+        });
+      });
+
+      it('should reset `isNewRecord` history state parameter', () => {
+        renderAuthorityViewRoute();
+
+        expect(mockHistoryReplace).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -113,39 +146,7 @@ describe('Given AuthorityViewRoute', () => {
     });
   });
 
-  describe('when authority is shared/local', () => {
-    it('should fetch the authority from the current tenant', () => {
-      const authority = {
-        shared: true,
-      };
-      const selectedAuthorityCtxValue = [authority];
-
-      renderAuthorityViewRoute(selectedAuthorityCtxValue);
-
-      expect(useAuthority.mock.calls[0][0]).toEqual({
-        tenantId: undefined,
-      });
-    });
-  });
-
   describe('when authority is shared', () => {
-    it('should fetch data from central tenant', () => {
-      const authority = {
-        shared: true,
-      };
-      const selectedAuthorityCtxValue = [authority];
-
-      renderAuthorityViewRoute(selectedAuthorityCtxValue);
-
-      expect(useMarcSource.mock.calls[0][0]).toEqual({
-        enabled: true,
-        tenantId: 'consortia',
-      });
-      expect(useAuthority.mock.calls[0][0]).toEqual({
-        tenantId: undefined,
-      });
-    });
-
     describe('when consortium info is not loaded', () => {
       beforeEach(() => {
         useStripes.mockReturnValueOnce({
@@ -174,7 +175,7 @@ describe('Given AuthorityViewRoute', () => {
   });
 
   describe('when authority is local', () => {
-    it('should fetch data with authority.tenantId', () => {
+    it('should fetch marc source data with authority.tenantId', () => {
       const authority = {
         shared: false,
         tenantId: 'university',
@@ -186,9 +187,6 @@ describe('Given AuthorityViewRoute', () => {
       expect(useMarcSource.mock.calls[0][0]).toEqual({
         enabled: true,
         tenantId: authority.tenantId,
-      });
-      expect(useAuthority.mock.calls[0][0]).toEqual({
-        tenantId: undefined,
       });
     });
 


### PR DESCRIPTION
## Description
The issue is caused by a missing check in a `useEffect` where we call `history.replace` to reset a `isNewRecord` parameter.
We only need to reset it to `false` when it's `true`, so this check is added now.
Also, `tenantId` has not been needed to fetch Authority records for a while, so we can remove tests that check for a `tenantId: undefined` in these calls

## Screenshots

https://github.com/user-attachments/assets/59470ab8-8e8d-443a-900f-34b67a674d53

## Issues
[UIMARCAUTH-537](https://folio-org.atlassian.net/browse/UIMARCAUTH-537)