### PR TITLE
UIMARCAUTH-539 Clear `selectedAuthority` on Authority View page unmount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [8.1.0] (IN PROGRESS)
 
 - [UIMARCAUTH-537](https://issues.folio.org/browse/UIMARCAUTH-537) Fix Authority View pane keeps opening and closing in Browse.
+- [UIMARCAUTH-539](https://issues.folio.org/browse/UIMARCAUTH-539) Clear `selectedAuthority` on Authority View page unmount.
 
 ## [8.0.1] (https://github.com/folio-org/ui-marc-authorities/tree/v8.0.1) (2026-05-28)
 

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -104,6 +104,8 @@ const AuthorityViewRoute = () => {
     }
   }, [authority?.data, setSelectedAuthority, selectedAuthority]);
 
+  // clear selected authority on unmount, so that we won't have any remaining data
+  // that could affect other parts of the app
   useEffect(() => {
     return () => {
       setSelectedAuthority(null);

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.js
@@ -105,6 +105,12 @@ const AuthorityViewRoute = () => {
   }, [authority?.data, setSelectedAuthority, selectedAuthority]);
 
   useEffect(() => {
+    return () => {
+      setSelectedAuthority(null);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     // `isNewRecord` is set in `CreateMarcAuthorityRoute` and is needed to
     // retry feching a created Authority record. The record might not be
     // available via search immediately after creation since reindexing might take

--- a/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
+++ b/src/routes/AuthorityViewRoute/AuthorityViewRoute.test.js
@@ -54,7 +54,8 @@ jest.mock('../../views/AuthorityView/AuthorityView', () => function () {
   return <div>AuthorityView</div>;
 });
 
-const renderAuthorityViewRoute = (selectedRecordCtxValue) => render(
+const defaultSelectedRecordCtxValue = [null, jest.fn()];
+const renderAuthorityViewRoute = (selectedRecordCtxValue = defaultSelectedRecordCtxValue) => render(
   <Harness selectedRecordCtxValue={selectedRecordCtxValue}>
     <AuthorityViewRoute />
   </Harness>,
@@ -162,7 +163,7 @@ describe('Given AuthorityViewRoute', () => {
         const authority = {
           shared: true,
         };
-        const selectedAuthorityCtxValue = [authority];
+        const selectedAuthorityCtxValue = [authority, jest.fn()];
 
         renderAuthorityViewRoute(selectedAuthorityCtxValue);
 
@@ -177,7 +178,7 @@ describe('Given AuthorityViewRoute', () => {
         shared: false,
         tenantId: 'university',
       };
-      const selectedAuthorityCtxValue = [authority];
+      const selectedAuthorityCtxValue = [authority, jest.fn()];
 
       renderAuthorityViewRoute(selectedAuthorityCtxValue);
 
@@ -206,7 +207,7 @@ describe('Given AuthorityViewRoute', () => {
           shared: false,
           tenantId: 'university',
         };
-        const selectedAuthorityCtxValue = [authority];
+        const selectedAuthorityCtxValue = [authority, jest.fn()];
 
         renderAuthorityViewRoute(selectedAuthorityCtxValue);
 


### PR DESCRIPTION
## Description
Fix issue with tab title still showing an opened Authority record title after clicking "Reset all".
`<AuthorityTitleManager>` uses `selectedAuthority` from context to update the tab name, and since `selectedAuthority` wasn't reset it would continue showing the last opened record title

## Issues
[UIMARCAUTH-539](https://folio-org.atlassian.net/browse/UIMARCAUTH-539)