### PR TITLE
UIMARCAUTH-521 Add a  aria-label for the Results List and Detail Record "Actions" buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-marc-authorities
 
+## [8.1.0] (IN PROGRESS)
+
+- [UIMARCAUTH-521](https://issues.folio.org/browse/UIMARCAUTH-521) Add a  aria-label for the Results List and Detail Record "Actions" buttons.
+
 ## [8.0.2] (https://github.com/folio-org/ui-marc-authorities/tree/v8.0.2) (2026-06-04)
 
 - [UIMARCAUTH-537](https://issues.folio.org/browse/UIMARCAUTH-537) Fix Authority View pane keeps opening and closing in Browse.

--- a/src/views/AuthoritiesSearch/AuthoritiesSearch.js
+++ b/src/views/AuthoritiesSearch/AuthoritiesSearch.js
@@ -712,6 +712,9 @@ const AuthoritiesSearch = ({
           paneSub={renderPaneSub()}
           firstMenu={renderResultsFirstMenu()}
           actionMenu={renderActionMenu}
+          actionMenuToggleProps={{
+            'aria-label': intl.formatMessage({ id: 'ui-marc-authorities.search-results-list.actionsMenu' }),
+          }}
           padContent={false}
           noOverflow
         >

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -285,6 +285,9 @@ const AuthorityView = ({
                     <DropdownButton
                       buttonStyle="primary"
                       marginBottom0
+                      actionMenuToggleProps={{
+                        'aria-label': intl.formatMessage({ id: 'ui-marc-authorities.authority-record.actionsMenu' }),
+                      }}
                       {...getTriggerProps()}
                     >
                       <FormattedMessage id="ui-marc-authorities.actions" />

--- a/src/views/AuthorityView/AuthorityView.js
+++ b/src/views/AuthorityView/AuthorityView.js
@@ -285,9 +285,7 @@ const AuthorityView = ({
                     <DropdownButton
                       buttonStyle="primary"
                       marginBottom0
-                      actionMenuToggleProps={{
-                        'aria-label': intl.formatMessage({ id: 'ui-marc-authorities.authority-record.actionsMenu' }),
-                      }}
+                      aria-label={intl.formatMessage({ id: 'ui-marc-authorities.authority-record.actionsMenu' })}
                       {...getTriggerProps()}
                     >
                       <FormattedMessage id="ui-marc-authorities.actions" />

--- a/translations/ui-marc-authorities/en.json
+++ b/translations/ui-marc-authorities/en.json
@@ -24,8 +24,10 @@
   "authorities.rows.recordsSelected": "{count, number} {count, plural, one {record} other {records}} selected",
   "authorities.rows.select": "Select Authority record",
 
+  "search-results-list.actionsMenu": "Show results list actions",
   "search-results-list.numberOfTitles": "Number of titles",
 
+  "authority-record.actionsMenu": "Show detail record actions",
   "authority-record.menuOptions": "Available options",
   "authority-record.edit": "Edit",
   "authority-record.export": "Export (MARC)",


### PR DESCRIPTION
## Description
Add a  aria-label for the Results List and Detail Record "Actions" buttons so that users who use screen readers can differentiate between different action menu buttons

## Issues
[UIMARCAUTH-521](https://folio-org.atlassian.net/browse/UIMARCAUTH-521)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2558