### PR TITLE
UIMARCAUTH-553: Set default values for new Authority records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [8.1.0] (IN PROGRESS)
 
 - [UIMARCAUTH-521](https://issues.folio.org/browse/UIMARCAUTH-521) Add a  aria-label for the Results List and Detail Record "Actions" buttons.
+- [UIMARCAUTH-553](https://issues.folio.org/browse/UIMARCAUTH-553) Set default field 008 values when creating a new authority.
 
 ## [8.0.2] (https://github.com/folio-org/ui-marc-authorities/tree/v8.0.2) (2026-06-04)
 

--- a/src/constants/createAuthorityMarcInitialValues.js
+++ b/src/constants/createAuthorityMarcInitialValues.js
@@ -5,16 +5,13 @@ export const INITIAL_AUTHORITY_VALUES = {
     {
       tag: '001',
       content: '',
-      isProtected: true,
     },
     {
       tag: '005',
       content: '',
-      isProtected: true,
     },
     {
       tag: '008',
-      isProtected: false,
       content: {
         'Undef_18': '\\\\\\\\\\\\\\\\\\\\',
         'Undef_30': '\\',
@@ -42,7 +39,6 @@ export const INITIAL_AUTHORITY_VALUES = {
     },
     {
       tag: '999',
-      isProtected: true,
       indicators: [
         'f',
         'f',

--- a/src/constants/createAuthorityMarcInitialValues.js
+++ b/src/constants/createAuthorityMarcInitialValues.js
@@ -1,6 +1,6 @@
 export const INITIAL_AUTHORITY_VALUES = {
   marcFormat: 'AUTHORITY',
-  leader: '00000nz\\\\a2200000o\\\\4500',
+  leader: String.raw`00000nz\\a2200000o\\4500`,
   fields: [
     {
       tag: '001',

--- a/src/constants/createAuthorityMarcInitialValues.js
+++ b/src/constants/createAuthorityMarcInitialValues.js
@@ -1,0 +1,53 @@
+export const INITIAL_AUTHORITY_VALUES = {
+  marcFormat: 'AUTHORITY',
+  leader: '00000nz\\\\a2200000o\\\\4500',
+  fields: [
+    {
+      tag: '001',
+      content: '',
+      isProtected: true,
+    },
+    {
+      tag: '005',
+      content: '',
+      isProtected: true,
+    },
+    {
+      tag: '008',
+      isProtected: false,
+      content: {
+        'Undef_18': '\\\\\\\\\\\\\\\\\\\\',
+        'Undef_30': '\\',
+        'Undef_34': '\\\\\\\\',
+        'Geo Subd': '\\',
+        'Roman': 'a',
+        'Lang': '|',
+        'Kind rec': 'a',
+        'Cat Rules': 'd',
+        'SH Sys': 'z',
+        'Series': '|',
+        'Numb Series': '|',
+        'Main use': 'a',
+        'Subj use': 'a',
+        'Series use': '|',
+        'Type Subd': 'a',
+        'Govt Ag': '|',
+        'RefEval': '|',
+        'RecUpd': 'a',
+        'Pers Name': '|',
+        'Level Est': '|',
+        'Mod Rec': '|',
+        'Source': 'd',
+      },
+    },
+    {
+      tag: '999',
+      isProtected: true,
+      indicators: [
+        'f',
+        'f',
+      ],
+      content: '',
+    },
+  ],
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,4 +4,5 @@ export * from './sortableColumns';
 export * from './queryKeys';
 export * from './exportAuthorityJobProfileId';
 export * from './createAuthorityRoute';
+export * from './createAuthorityMarcInitialValues';
 export * from './constants';

--- a/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.js
+++ b/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.js
@@ -11,6 +11,8 @@ import { FormattedMessage } from 'react-intl';
 import { Pluggable } from '@folio/stripes/core';
 import { AuthoritiesSearchContext } from '@folio/stripes-authority-components';
 
+import { INITIAL_AUTHORITY_VALUES } from '../../constants';
+
 export const CreateMarcAuthorityRoute = () => {
   const history = useHistory();
   const location = useLocation();
@@ -59,6 +61,7 @@ export const CreateMarcAuthorityRoute = () => {
         isShared={isShared}
         useRoutes={false}
         onCreateAndKeepEditing={onCreateAndKeepEditing}
+        initialValues={INITIAL_AUTHORITY_VALUES}
       >
         <span data-test-marc-authorities-quick-marc-no-plugin>
           <FormattedMessage id="ui-marc-authorities.quickMarcNotAvailable" />

--- a/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
+++ b/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
@@ -86,7 +86,7 @@ describe('CreateMarcAuthorityRoute', () => {
           ]),
         }),
       }),
-      {}
+      {},
     );
   });
 

--- a/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
+++ b/src/routes/CreateMarcAuthorityRoute/CreateMarcAuthorityRoute.test.js
@@ -9,7 +9,7 @@ import {
   render,
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
-import { useStripes } from '@folio/stripes/core';
+import { useStripes, Pluggable } from '@folio/stripes/core';
 
 import { CreateMarcAuthorityRoute } from './CreateMarcAuthorityRoute';
 import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
@@ -69,6 +69,25 @@ describe('CreateMarcAuthorityRoute', () => {
     renderCreateMarcAuthorityRoute();
 
     expect(screen.getByText('Pluggable')).toBeInTheDocument();
+
+    expect(Pluggable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValues: expect.objectContaining({
+          marcFormat: 'AUTHORITY',
+          leader: expect.stringMatching(/^00000nz/),
+          fields: expect.arrayContaining([
+            expect.objectContaining({ tag: '001' }),
+            expect.objectContaining({ tag: '005' }),
+            expect.objectContaining({
+              tag: '008',
+              content: expect.objectContaining({ RecUpd: 'a' }),
+            }),
+            expect.objectContaining({ tag: '999' }),
+          ]),
+        }),
+      }),
+      {}
+    );
   });
 
   describe('when handling save and keep editing', () => {


### PR DESCRIPTION
## Purpose

Provide default settings for required parts of field 008 so users don't need to fill every one in by hand every time.

## Approach

Use QuickMarc pluggable's `initialValues` property to pass in defaults, also including leader, 001, 005, and 999 to match what QuicMarc itself provides for initial values.

## Refs
https://folio-org.atlassian.net/browse/UIMARCAUTH-553

## Screenshots

<img width="1376" height="892" alt="Screenshot 2026-08-18 at 13 52 18" src="https://github.com/user-attachments/assets/2da44b0d-de5b-4223-b64d-1188ad4add28" />
